### PR TITLE
Update README to add PyPI version badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,5 +7,7 @@ SII
 .. image:: https://coveralls.io/repos/github/gisce/sii/badge.svg?branch=master
     :target: https://coveralls.io/github/gisce/sii?branch=master
 
+.. image:: https://img.shields.io/pypi/v/sii.svg
+    :target: https://pypi.python.org/pypi/mamba
 
 AEAT Suministro Inmediato de Información


### PR DESCRIPTION
This PR adds the badge ![](https://img.shields.io/pypi/v/sii.svg) to README