### PR TITLE
Añadir modelos para consultar facturas

### DIFF
--- a/sii/models/invoices.py
+++ b/sii/models/invoices.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+
+from marshmallow import Schema, fields, post_dump
+from marshmallow import validate, validates, validates_schema, ValidationError
+from sii import __SII_VERSION__
+from datetime import datetime
+
+PERIODO_VALUES = [
+    '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '0A'
+]
+
+
+class DateString(fields.String):
+    def _validate(self, value):
+        if value is None:
+            return None
+        try:
+            datetime.strptime(value, '%Y-%m-%d')
+        except (ValueError, AttributeError):
+            raise ValidationError('Invalid date string', value)
+
+    @post_dump
+    def _serialize(self, value, attr, obj):
+        return datetime.strptime(value, '%Y-%m-%d').strftime('%d-%m-%Y')
+
+
+class MySchema(Schema):
+    @validates_schema(pass_original=True)
+    def check_unknown_fields(self, data, original_data):
+        unknown = list(set(original_data) - set(self.fields))
+        if unknown:
+            raise ValidationError('Unknown field', unknown)
+
+
+class NIF(MySchema):
+    NIF = fields.String(required=True, validate=validate.Length(max=9))
+
+
+class Titular(NIF):
+    NombreRazon = fields.String(
+        required=True, validate=validate.Length(max=120)
+    )
+
+
+class Contraparte(Titular):
+    pass
+
+
+class Cabecera(MySchema):
+    IDVersionSii = fields.String(required=True, default=__SII_VERSION__)
+    Titular = fields.Nested(Titular, required=True)
+
+
+class PeriodoImpositivo(MySchema):
+    Ejercicio = fields.String(
+        required=True,
+        validate=validate.OneOf([str(x) for x in range(0, 10000)])
+    )
+    Periodo = fields.String(
+        required=True, validate=validate.OneOf(PERIODO_VALUES)
+    )

--- a/sii/models/invoices_consult.py
+++ b/sii/models/invoices_consult.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+
+from marshmallow import fields, validate
+from invoices import MySchema, DateString
+from invoices import Cabecera, PeriodoImpositivo, Contraparte
+
+FACTURA_MODIFICADA_VALUES = ['S', 'N']
+
+
+class RangoFechaPresentacion(MySchema):
+    Desde = DateString()
+    Hasta = DateString()
+
+
+class FiltroConsulta(MySchema):
+    PeriodoImpositivo = fields.Nested(PeriodoImpositivo, required=True)
+    # TODO add IDFactura
+    Contraparte = fields.Nested(Contraparte)
+    FechaPresentacion = fields.Nested(RangoFechaPresentacion)
+    FacturaModificada = fields.String(
+        validate=validate.OneOf(FACTURA_MODIFICADA_VALUES)
+    )
+    # TODO add EstadoCuadre
+    # TODO add ClavePaginacion
+
+
+class ConsultaFacturas(MySchema):
+    Cabecera = fields.Nested(Cabecera, required=True)
+
+
+class ConsultaFacturasRecibidas(ConsultaFacturas):
+    FiltroConsulta = fields.Nested(FiltroConsulta, required=True)
+
+
+class ConsultaLRFacturasRecibidas(MySchema):
+    ConsultaLRFacturasRecibidas = fields.Nested(
+        ConsultaFacturasRecibidas, required=True
+    )
+
+
+class ConsultaFacturasRecibidas(ConsultaFacturas):
+    FiltroConsulta = fields.Nested(FiltroConsulta, required=True)
+
+
+class ConsultaLRFacturasEmitidas(MySchema):
+    ConsultaLRFacturasEmitidas = fields.Nested(
+        ConsultaFacturasEmitidas, required=True
+    )


### PR DESCRIPTION
Closes #20 

Informació AEAT: [¿La consulta de facturas emitidas o recibidas vía servicio web devuelve aquellas que han sido anuladas?](http://www.agenciatributaria.es/AEAT.internet/Inicio/Ayuda/Modelos__Procedimientos_y_Servicios/Ayuda_P_G417____IVA__Llevanza_de_libros_registro__SII_/Ayuda_tecnica/Informacion_tecnica_SII/Preguntas_tecnicas_frecuentes/1__Cuestiones_Generales/56__La_consulta_de_facturas_emitidas_o_recibidas_via_servicio_web_devuelve_aquellas_que_han_sido_anuladas_.shtml)

This PR adds models needed to:

- [ ] Consult invoices registered
