### PR TITLE
Add marshmallow>=2.13.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-marshmallow
+marshmallow>=2.13.5
 zeep


### PR DESCRIPTION
This PR is to add the last marshmallow version (2.13.5) to requirements in order to avoid problems with older versions that use [`fields.Select` instead of `OneOf`](http://marshmallow.readthedocs.io/en/latest/upgrading.html#use-oneof-instead-of-fields-select)