### PR TITLE
Fix clave regimen especial without fiscal position

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -101,9 +101,14 @@ def get_factura_emitida(invoice):
     if invoice.fiscal_position:
         clave_regimen_escpecial = \
             invoice.fiscal_position.sii_out_clave_regimen_especial
-    else:
+    elif invoice.partner_id.property_account_position:
+        clave_regimen_escpecial = \
+            invoice.partner_id.property_account_position.sii_out_clave_regimen_especial
+    elif invoice.journal_id:
         clave_regimen_escpecial = \
             invoice.journal_id.sii_out_clave_regimen_especial
+    else:
+        raise AttributeError('La Factura no tiene Clave de Régimen Especial')
 
     factura_expedida = {
         'TipoFactura': 'R4' if invoice.rectificative_type == 'R' else 'F1',

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -86,7 +86,7 @@ def get_factura_emitida(invoice):
     if invoice.partner_id.aeat_registered:
         contraparte = {
             'NombreRazon': invoice.partner_id.name,
-            'NIF': invoice.partner_id.vat# +'a'
+            'NIF': invoice.partner_id.vat
         }
     else:
         contraparte = {

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -98,10 +98,16 @@ def get_factura_emitida(invoice):
             }
         }
 
+    if invoice.fiscal_position:
+        clave_regimen_escpecial = \
+            invoice.fiscal_position.sii_out_clave_regimen_especial
+    else:
+        clave_regimen_escpecial = \
+            invoice.journal_id.sii_out_clave_regimen_especial
+
     factura_expedida = {
         'TipoFactura': 'R4' if invoice.rectificative_type == 'R' else 'F1',
-        'ClaveRegimenEspecialOTrascendencia':
-            invoice.fiscal_position.sii_out_clave_regimen_especial,
+        'ClaveRegimenEspecialOTrascendencia': clave_regimen_escpecial,
         'ImporteTotal': SIGN[invoice.rectificative_type] * invoice.amount_total,
         'DescripcionOperacion': invoice.journal_id.name,
         'Contraparte': contraparte,
@@ -138,10 +144,16 @@ def get_factura_recibida(invoice):
             }
         }
 
+    if invoice.fiscal_position:
+        clave_regimen_escpecial = \
+            invoice.fiscal_position.sii_in_clave_regimen_especial
+    else:
+        clave_regimen_escpecial = \
+            invoice.journal_id.sii_in_clave_regimen_especial
+
     factura_recibida = {
         'TipoFactura': 'R4' if invoice.rectificative_type == 'R' else 'F1',
-        'ClaveRegimenEspecialOTrascendencia':
-            invoice.fiscal_position.sii_in_clave_regimen_especial,
+        'ClaveRegimenEspecialOTrascendencia': clave_regimen_escpecial,
         'ImporteTotal': SIGN[invoice.rectificative_type] * invoice.amount_total,
         'DescripcionOperacion': invoice.journal_id.name,
         'Contraparte': {

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -22,8 +22,10 @@ class Partner:
 
 
 class Journal:
-    def __init__(self, name):
+    def __init__(self, name, cre_in_invoice, cre_out_invoice):
         self.name = name
+        self.sii_in_clave_regimen_especial = cre_in_invoice
+        self.sii_out_clave_regimen_especial = cre_out_invoice
 
 
 class FiscalPosition:
@@ -169,7 +171,10 @@ class DataGenerator:
         )
 
     def get_in_invoice(self):
-        journal = Journal(name='Factura de Energía Recibida')
+        journal = Journal(
+            name='Factura de Energía Recibida',
+            cre_in_invoice='01', cre_out_invoice='01'
+        )
 
         invoice = Invoice(
             type='in_invoice',
@@ -190,7 +195,10 @@ class DataGenerator:
         return invoice
 
     def get_out_invoice(self):
-        journal = Journal(name='Factura de Energía Emitida')
+        journal = Journal(
+            name='Factura de Energía Emitida',
+            cre_in_invoice='01', cre_out_invoice='01'
+        )
 
         invoice = Invoice(
             type='out_invoice',
@@ -210,7 +218,10 @@ class DataGenerator:
         return invoice
 
     def get_in_refund_invoice(self):
-        journal = Journal(name='Factura de Energía Rectificativa Recibida')
+        journal = Journal(
+            name='Factura de Energía Rectificativa Recibida',
+            cre_in_invoice='01', cre_out_invoice='01'
+        )
 
         invoice = Invoice(
             type='in_refund',
@@ -231,7 +242,10 @@ class DataGenerator:
         return invoice
 
     def get_out_refund_invoice(self):
-        journal = Journal(name='Factura de Energía Rectificativa Emitida')
+        journal = Journal(
+            name='Factura de Energía Rectificativa Emitida',
+            cre_in_invoice='01', cre_out_invoice='01'
+        )
 
         invoice = Invoice(
             type='out_refund',


### PR DESCRIPTION
This PR fixes `bool obj has no attribute name` when trying to get Clave Regimen Especial from `invoice.fiscal_position` when Fiscal Position is not assigned