### PR TITLE
Change TipoNoExenta to S2 'Inv. Suj. Pasivo'

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -67,7 +67,7 @@ def get_factura_emitida(invoice):
                 iva_values['detalle_iva_exento']
         if iva_values['iva_no_exento']:
             desglose_factura['Sujeta']['NoExenta'] = {
-                'TipoNoExenta': 'S1',
+                'TipoNoExenta': 'S2',
                 'DesgloseIVA': {
                     'DetalleIVA': iva_values['detalle_iva']
                 }


### PR DESCRIPTION
Closes #57 

This PR sets Out Invoices with `'S2'` as `TipoNoExenta` type which means ['No exenta - Con Inversion sujeto pasivo'](https://github.com/gisce/sii/blob/fix_register_out_invoice_with_iva/sii/data/SuministroInformacion.xsd#L1072)