### PR TITLE
Fix IVA values

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -41,13 +41,13 @@ def get_iva_values(invoice, in_invoice):
             else:
                 sign = SIGN[invoice.rectificative_type]
                 iva = {
-                    'BaseImponible': sign * inv_tax.base,
+                    'BaseImponible': sign * abs(inv_tax.base),
                     'TipoImpositivo': inv_tax.tax_id.amount * 100
                 }
                 if in_invoice:
-                    iva['CuotaRepercutida'] = sign * inv_tax.tax_amount
+                    iva['CuotaRepercutida'] = sign * abs(inv_tax.tax_amount)
                 else:
-                    iva['CuotaSoportada'] = sign * inv_tax.tax_amount
+                    iva['CuotaSoportada'] = sign * abs(inv_tax.tax_amount)
                 vals['iva_no_exento'] = True
                 vals['detalle_iva'].append(iva)
         else:

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -50,7 +50,7 @@ def get_iva_values(invoice, in_invoice):
                     iva['CuotaSoportada'] = sign * abs(inv_tax.tax_amount)
                 vals['iva_no_exento'] = True
                 vals['detalle_iva'].append(iva)
-        elif 'Impuesto especial sobre la electricidad' != inv_tax.name.lower():
+        elif 'sobre la electricidad' not in inv_tax.name.lower():
             vals['no_sujeta_a_iva'] = True
     return vals
 

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -50,7 +50,7 @@ def get_iva_values(invoice, in_invoice):
                     iva['CuotaSoportada'] = sign * abs(inv_tax.tax_amount)
                 vals['iva_no_exento'] = True
                 vals['detalle_iva'].append(iva)
-        else:
+        elif 'Impuesto especial sobre la electricidad' != inv_tax.name.lower():
             vals['no_sujeta_a_iva'] = True
     return vals
 


### PR DESCRIPTION
This PR is to always use negative value if the invoice has type 'A' (Anuladora) or 'B' (Anuladora con sustituyente)