### PR TITLE
Upgrade SII version to 1.0

### DIFF
--- a/sii/__init__.py
+++ b/sii/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 __LIBRARY_VERSION__ = '0.3.6'
-__SII_VERSION__ = '0.7'
+__SII_VERSION__ = '1.0'

--- a/sii/data/SuministroInformacion.xsd
+++ b/sii/data/SuministroInformacion.xsd
@@ -22,6 +22,15 @@
 			<element name="Cabecera" type="sii:CabeceraSiiBaja"/>
 		</sequence>
 	</complexType>
+	<complexType name="SuministroInformacionCobrosPagos">
+		<annotation>
+			<documentation xml:lang="es"> Sii - Suministro Inmediato de Información, compuesto por datos 
+			                              de contexto y una secuencia de 1 o más registros. </documentation>
+		</annotation>
+		<sequence>
+			<element name="Cabecera" type="sii:CabeceraSiiCobrosPagos"/>
+		</sequence>
+	</complexType>
 	<complexType name="ConsultaInformacion">
 		<annotation>
 			<documentation xml:lang="es"> Sii - Suministro Inmediato de Información, compuesto por datos 
@@ -48,6 +57,19 @@
 		</sequence>
 	</complexType>
 	<complexType name="CabeceraSiiBaja">
+		<annotation>
+			<documentation xml:lang="es"> Datos de contexto de un suministro sin especificar el timpo de comunicacion </documentation>
+		</annotation>
+		<sequence>
+			<element name="IDVersionSii" type="sii:VersionSiiType"/>
+			<element name="Titular" type="sii:PersonaFisicaJuridicaESType">
+				<annotation>
+					<documentation xml:lang="es"> Titular de los libros de registro que suministra la información </documentation>
+				</annotation>
+			</element>
+		</sequence>
+	</complexType>
+	<complexType name="CabeceraSiiCobrosPagos">
 		<annotation>
 			<documentation xml:lang="es"> Datos de contexto de un suministro sin especificar el timpo de comunicacion </documentation>
 		</annotation>
@@ -836,7 +858,7 @@
 	</complexType>
 	<simpleType name="VersionSiiType">
 		<restriction base="string">
-			<enumeration value="0.7"/>
+			<enumeration value="1.0"/>
 		</restriction>
 	</simpleType>
 	<!-- ==== Tipos básicos (Listas de claves y patrones) ============================================= -->
@@ -1623,6 +1645,7 @@
 			<enumeration value="DJ"/>
 			<enumeration value="ZM"/>
 			<enumeration value="ZW"/>
+			<enumeration value="QU"/>
 		</restriction>
 	</simpleType>
 	<simpleType name="CountryMiembroType">

--- a/sii/data/SuministroLR.xsd
+++ b/sii/data/SuministroLR.xsd
@@ -235,7 +235,7 @@
 			<complexContent>
 				<extension base="sii:SuministroInformacion">
 					<sequence>
-						<element name="RegistroLRBajaCobrosMetalico" type="siiLR:LRCobrosMetalicoType" maxOccurs="10000"/>
+						<element name="RegistroLRCobrosMetalico" type="siiLR:LRCobrosMetalicoType" maxOccurs="10000"/>
 					</sequence>
 				</extension>
 			</complexContent>
@@ -264,7 +264,7 @@
 			<complexContent>
 				<extension base="sii:SuministroInformacionBaja">
 					<sequence>
-						<element name="RegistroLRCobrosMetalico" type="siiLR:LRBajaCobrosMetalicoType" maxOccurs="10000"/>
+						<element name="RegistroLRBajaCobrosMetalico" type="siiLR:LRBajaCobrosMetalicoType" maxOccurs="10000"/>
 					</sequence>
 				</extension>
 			</complexContent>
@@ -416,7 +416,7 @@
 		</annotation>
 		<complexType>
 			<complexContent>
-				<extension base="sii:SuministroInformacionBaja">
+				<extension base="sii:SuministroInformacionCobrosPagos">
 					<sequence>
 						<element name="RegistroLRCobros" type="siiLR:LRCobrosEmitidasType" maxOccurs="10000"/>
 					</sequence>
@@ -439,7 +439,7 @@
 		</annotation>
 		<complexType>
 			<complexContent>
-				<extension base="sii:SuministroInformacionBaja">
+				<extension base="sii:SuministroInformacionCobrosPagos">
 					<sequence>
 						<element name="RegistroLRPagos" type="siiLR:LRPagosEmitidasType" maxOccurs="10000"/>
 					</sequence>

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -20,7 +20,7 @@ with description('El XML Generado'):
             )
 
         with it('la versión es la "0.7"'):
-            expect(self.cabecera['IDVersionSii']).to(equal('0.7'))
+            expect(self.cabecera['IDVersionSii']).to(equal('1.0'))
 
         with context('cuando es de tipo alta'):
             with it('el tipo de comunicación debe ser "A0"'):


### PR DESCRIPTION
This PR adds the following updates for SII Version 1.0 comming at 01/07/2017:

- [x] Se modifican los WSDL para incorporar los EndPoints de producción
- [x] Se modifica el xsd SuministroInformacion con la versión actual del esquema que es la 1.0
- [x] Se actualizan los ejemplos XML con la versión 1.0. Sólo se modifica la etiqueta `<sii:IDVersionSii>1.0</sii:IDVersionSii>`