### PR TITLE
Use CRE only from invoice

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -99,21 +99,10 @@ def get_factura_emitida(invoice):
             }
         }
 
-    if invoice.fiscal_position:
-        clave_regimen_escpecial = \
-            invoice.fiscal_position.sii_out_clave_regimen_especial
-    elif invoice.partner_id.property_account_position:
-        clave_regimen_escpecial = \
-            invoice.partner_id.property_account_position.sii_out_clave_regimen_especial
-    elif invoice.journal_id:
-        clave_regimen_escpecial = \
-            invoice.journal_id.sii_out_clave_regimen_especial
-    else:
-        raise AttributeError('La Factura no tiene Clave de Régimen Especial')
-
     factura_expedida = {
         'TipoFactura': 'R4' if invoice.rectificative_type == 'R' else 'F1',
-        'ClaveRegimenEspecialOTrascendencia': clave_regimen_escpecial,
+        'ClaveRegimenEspecialOTrascendencia':
+            invoice.sii_out_clave_regimen_especial,
         'ImporteTotal': SIGN[invoice.rectificative_type] * invoice.amount_total,
         'DescripcionOperacion': invoice.journal_id.name,
         'Contraparte': contraparte,
@@ -150,16 +139,10 @@ def get_factura_recibida(invoice):
             }
         }
 
-    if invoice.fiscal_position:
-        clave_regimen_escpecial = \
-            invoice.fiscal_position.sii_in_clave_regimen_especial
-    else:
-        clave_regimen_escpecial = \
-            invoice.journal_id.sii_in_clave_regimen_especial
-
     factura_recibida = {
         'TipoFactura': 'R4' if invoice.rectificative_type == 'R' else 'F1',
-        'ClaveRegimenEspecialOTrascendencia': clave_regimen_escpecial,
+        'ClaveRegimenEspecialOTrascendencia':
+            invoice.sii_in_clave_regimen_especial,
         'ImporteTotal': SIGN[invoice.rectificative_type] * invoice.amount_total,
         'DescripcionOperacion': invoice.journal_id.name,
         'Contraparte': {

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -22,17 +22,13 @@ class Partner:
 
 
 class Journal:
-    def __init__(self, name, cre_in_invoice, cre_out_invoice):
+    def __init__(self, name):
         self.name = name
-        self.sii_in_clave_regimen_especial = cre_in_invoice
-        self.sii_out_clave_regimen_especial = cre_out_invoice
 
 
 class FiscalPosition:
-    def __init__(self, name, cre_in_invoice, cre_out_invoice):
+    def __init__(self, name):
         self.name = name
-        self.sii_in_clave_regimen_especial = cre_in_invoice
-        self.sii_out_clave_regimen_especial = cre_out_invoice
 
 
 class Tax:
@@ -163,17 +159,13 @@ class DataGenerator:
         taxes_amount = sum([tax.tax_amount for tax in self.tax_line])
         base_amount = sum([line.price_subtotal for line in self.invoice_line])
         self.amount_total = taxes_amount + base_amount
-        cre_in_invoice = '01'
-        cre_out_invoice = '01'
         self.fiscal_position = FiscalPosition(
-            name=u'Régimen Islas Canarias', cre_in_invoice=cre_in_invoice,
-            cre_out_invoice=cre_out_invoice
+            name=u'Régimen Islas Canarias'
         )
 
     def get_in_invoice(self):
         journal = Journal(
-            name='Factura de Energía Recibida',
-            cre_in_invoice='01', cre_out_invoice='01'
+            name='Factura de Energía Recibida'
         )
 
         invoice = Invoice(
@@ -196,8 +188,7 @@ class DataGenerator:
 
     def get_out_invoice(self):
         journal = Journal(
-            name='Factura de Energía Emitida',
-            cre_in_invoice='01', cre_out_invoice='01'
+            name='Factura de Energía Emitida'
         )
 
         invoice = Invoice(
@@ -219,8 +210,7 @@ class DataGenerator:
 
     def get_in_refund_invoice(self):
         journal = Journal(
-            name='Factura de Energía Rectificativa Recibida',
-            cre_in_invoice='01', cre_out_invoice='01'
+            name='Factura de Energía Rectificativa Recibida'
         )
 
         invoice = Invoice(
@@ -243,8 +233,7 @@ class DataGenerator:
 
     def get_out_refund_invoice(self):
         journal = Journal(
-            name='Factura de Energía Rectificativa Emitida',
-            cre_in_invoice='01', cre_out_invoice='01'
+            name='Factura de Energía Rectificativa Emitida'
         )
 
         invoice = Invoice(

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -56,6 +56,7 @@ class Invoice:
     def __init__(self, journal_id, number, type, partner_id, company_id,
                  amount_total, period_id, date_invoice, tax_line, sii_registered,
                  rectificative_type, fiscal_position, invoice_line,
+                 sii_in_clave_regimen_especial, sii_out_clave_regimen_especial,
                  origin=None):
         self.journal_id = journal_id
         self.number = number
@@ -70,6 +71,8 @@ class Invoice:
         self.fiscal_position = fiscal_position
         self.sii_registered = sii_registered
         self.origin = origin
+        self.sii_in_clave_regimen_especial = sii_in_clave_regimen_especial
+        self.sii_out_clave_regimen_especial = sii_out_clave_regimen_especial
         self.rectificative_type = rectificative_type
 
 
@@ -162,6 +165,8 @@ class DataGenerator:
         self.fiscal_position = FiscalPosition(
             name=u'Régimen Islas Canarias'
         )
+        self.sii_in_clave_regimen_especial = '01'
+        self.sii_out_clave_regimen_especial = '01'
 
     def get_in_invoice(self):
         journal = Journal(
@@ -182,7 +187,9 @@ class DataGenerator:
             tax_line=self.tax_line,
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
-            fiscal_position=self.fiscal_position
+            fiscal_position=self.fiscal_position,
+            sii_in_clave_regimen_especial=self.sii_in_clave_regimen_especial,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial
         )
         return invoice
 
@@ -204,7 +211,9 @@ class DataGenerator:
             tax_line=self.tax_line,
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
-            fiscal_position=self.fiscal_position
+            fiscal_position=self.fiscal_position,
+            sii_in_clave_regimen_especial=self.sii_in_clave_regimen_especial,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial
         )
         return invoice
 
@@ -227,7 +236,9 @@ class DataGenerator:
             tax_line=self.tax_line,
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
-            fiscal_position=self.fiscal_position
+            fiscal_position=self.fiscal_position,
+            sii_in_clave_regimen_especial=self.sii_in_clave_regimen_especial,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial
         )
         return invoice
 
@@ -249,6 +260,8 @@ class DataGenerator:
             tax_line=self.tax_line,
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
-            fiscal_position=self.fiscal_position
+            fiscal_position=self.fiscal_position,
+            sii_in_clave_regimen_especial=self.sii_in_clave_regimen_especial,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial
         )
         return invoice


### PR DESCRIPTION
Requires https://github.com/gisce/erp/pull/4729 to be merged to main SII Module

This PR uses `invoice.sii_out_clave_regimen_especial` or `invoice.sii_in_clave_regimen_especial` instead of getting it from fiscal_position or journal