### PR TITLE
Add get contraparte and get partner vat type

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -144,9 +144,9 @@ def get_factura_recibida(invoice):
     else:
         desglose_factura = {
             'DesgloseIVA': {
-                'DetalleIVA': {
+                'DetalleIVA': [{
                     'BaseImponible': 0  # TODO deixem de moment 0 perquè no tindrem inversio sujeto pasivo
-                }
+                }]
             }
         }
 

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -51,7 +51,7 @@ def get_iva_values(invoice, in_invoice):
 
 
 def get_contraparte(partner, in_invoice):
-    vat_type = partner.get_vat_type()
+    vat_type = partner.sii_get_vat_type()
     contraparte = {'NombreRazon': partner.name}
 
     if not partner.aeat_registered and not in_invoice:

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -8,21 +8,6 @@ from sii.models import invoices_record
 SIGN = {'B': -1, 'A': -1, 'N': 1, 'R': 1}
 
 
-def get_importe_no_sujeto_a_iva(invoice):
-    importe_no_sujeto = 0
-
-    for line in invoice.invoice_line:
-        no_iva = True
-        for tax in line.invoice_line_tax_id:
-            if 'iva' in tax.name.lower():
-                no_iva = False
-                break
-        if no_iva:
-            importe_no_sujeto += line.price_subtotal
-
-    return importe_no_sujeto
-
-
 def get_iva_values(invoice, in_invoice):
     vals = {
         'sujeta_a_iva': False,

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -102,21 +102,6 @@ def get_factura_emitida(invoice):
                 'ImportePorArticulos7_14_Otros': importe_no_sujeto
             }
 
-    if invoice.partner_id.aeat_registered:
-        contraparte = {
-            'NombreRazon': invoice.partner_id.name,
-            'NIF': invoice.partner_id.vat
-        }
-    else:
-        contraparte = {
-            'NombreRazon': invoice.partner_id.name,
-            'IDOtro': {
-                'CodigoPais': 'ES',
-                'IDType': '07',
-                'ID': invoice.partner_id.vat
-            }
-        }
-
     if invoice.fiscal_position:
         clave_regimen_escpecial = \
             invoice.fiscal_position.sii_out_clave_regimen_especial

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -45,9 +45,9 @@ def get_iva_values(invoice, in_invoice):
                     'TipoImpositivo': inv_tax.tax_id.amount * 100
                 }
                 if in_invoice:
-                    iva['CuotaRepercutida'] = sign * abs(inv_tax.tax_amount)
-                else:
                     iva['CuotaSoportada'] = sign * abs(inv_tax.tax_amount)
+                else:
+                    iva['CuotaRepercutida'] = sign * abs(inv_tax.tax_amount)
                 vals['iva_no_exento'] = True
                 vals['detalle_iva'].append(iva)
         elif 'sobre la electricidad' not in inv_tax.name.lower():
@@ -56,7 +56,7 @@ def get_iva_values(invoice, in_invoice):
 
 
 def get_factura_emitida(invoice):
-    iva_values = get_iva_values(invoice, in_invoice=True)
+    iva_values = get_iva_values(invoice, in_invoice=False)
     desglose_factura = {}
 
     if iva_values['sujeta_a_iva']:
@@ -126,7 +126,7 @@ def get_factura_emitida(invoice):
 
 
 def get_factura_recibida(invoice):
-    iva_values = get_iva_values(invoice, in_invoice=False)
+    iva_values = get_iva_values(invoice, in_invoice=True)
     cuota_deducible = 0
 
     if iva_values['sujeta_a_iva'] and iva_values['iva_no_exento']:

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -14,10 +14,16 @@ class Company:
         self.partner_id = partner_id
 
 
+class Country:
+    def __init__(self, code):
+        self.code = code
+
+
 class Partner:
-    def __init__(self, name, nif, aeat_registered=True):
+    def __init__(self, name, nif, country, aeat_registered=True):
         self.name = name
         self.vat = nif
+        self.country = country
         self.aeat_registered = aeat_registered
 
 
@@ -146,15 +152,15 @@ class DataGenerator:
             invoice_tax_iva_21, invoice_tax_iva_4, invoice_tax_ibi,
             invoice_tax_iva_exento
         ]
-
+        spain = Country(code='ES')
         self.partner_invoice = Partner(
             name=os.environ.get('NOMBRE_CONTRAPARTE', u'Francisco García'),
             nif=os.environ.get('NIF_CONTRAPARTE', u'12345678T'),
-            aeat_registered=contraparte_registered
+            country=spain, aeat_registered=contraparte_registered
         )
         partner_company = Partner(
             name=os.environ.get('NOMBRE_TITULAR', u'Compañía Eléctrica S.A.'),
-            nif=os.environ.get('NIF_TITULAR', '55555555T')
+            nif=os.environ.get('NIF_TITULAR', '55555555T'), country=spain
         )
         self.company = Company(partner_id=partner_company)
 

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -26,7 +26,7 @@ class Partner:
         self.country = country
         self.aeat_registered = aeat_registered
 
-    def get_vat_type(self):
+    def sii_get_vat_type(self):
         return '02'
 
 

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -26,6 +26,9 @@ class Partner:
         self.country = country
         self.aeat_registered = aeat_registered
 
+    def get_vat_type(self):
+        return '02'
+
 
 class Journal:
     def __init__(self, name, cre_in_invoice, cre_out_invoice):


### PR DESCRIPTION
This PR adds:

- Function `get_contraparte` to get the dictionary for the `invoice.partner_id`
- Registers partner VAT Type depending on `partner_id.get_vat_type`