### PR TITLE
Add marshmallow custom error messages

### DIFF
--- a/sii/models/invoices_record.py
+++ b/sii/models/invoices_record.py
@@ -1,9 +1,10 @@
 # coding=utf-8
 
 from marshmallow import Schema, fields, post_dump
-from marshmallow import validate, validates, validates_schema, ValidationError
+from marshmallow import validates_schema, ValidationError
 from sii import __SII_VERSION__
 from datetime import datetime
+import re
 
 TIPO_COMUNICACION_VALUES = ['A0', 'A1', 'A4']
 

--- a/sii/models/invoices_record.py
+++ b/sii/models/invoices_record.py
@@ -110,6 +110,11 @@ CRE_FACTURAS_RECIBIDAS = [
 ]
 
 
+def convert_camel_case_to_underscore(name):
+    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+
 class DateString(fields.String):
     def _validate(self, value):
         if value is None:

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -267,16 +267,33 @@ class SII(object):
                 self.invoice, rectificativa=rectificativa
             )
         else:
-            raise AttributeError('Unknown value in invoice.type')
+            raise AttributeError(
+                'Valor desconocido en el tipo de factura: {}'.format(
+                    invoice.type
+                )
+            )
+
+    def get_validation_errors_list(self, errors):
+        error_messages = []
+
+        for val in errors.values():
+            if isinstance(val, dict):
+                error_messages += self.get_validation_errors_list(val)
+            else:
+                error_messages += val
+
+        return error_messages
 
     def validate_invoice(self):
 
+        res = {}
+
         errors = self.invoice_model.validate(self.invoice_dict)
 
-        res = {
-            'successful': False if errors else True,
-            'errors': errors
-        }
+        res['successful'] = False if errors else True
+        if errors:
+            errors_list = self.get_validation_errors_list(errors)
+            res['errors'] = errors_list
 
         return res
 


### PR DESCRIPTION
Closes #41 

This PR defines:

- `get_atleast_one_of(choices)`: returns list of field names which at least one of the choices should be included in the model
- `get_atleast_one_of_error_message`: returns default error message in case none of the above choices are included in the model
- `validate_field_max_length(value, field_name, max_chars)`: validates a field length and raises `ValidationError` if it is longer than `max_chars`
- `validate_field_is_one_of(value, field_name, choices)`: validates if value is an element of choices
- `get_default_max_length_message`: returns default maximum length message in case length validator fails
- `validate_all_fields`: checks for an existing field validator and runs it. Raises a `ValidationError` with all fields errors in a list
- `validate_atleast_one_of`: validates models with `get_atleast_one_of` function

This PR also:

- Replaces `validate.Length` validators and `validate.OneOf` for the above functions in models
- Returns an errors list when validating a model failed