### PR TITLE
Avoid calling upper() on partner vat if it doesnt exist

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -283,7 +283,8 @@ def get_factura_recibida_dict(invoice, rectificativa=False):
 
 def refactor_nifs(invoice):
     for partner in (invoice.partner_id, invoice.company_id.partner_id):
-        partner.vat = re.sub('^ES', '', partner.vat.upper())
+        if partner.vat:
+            partner.vat = re.sub('^ES', '', partner.vat.upper())
 
 
 class SII(object):


### PR DESCRIPTION
This PR is to avoid calling a function to partner vat if it is empty