### PR TITLE
Get sii_description from invoice instead of getting it from journal

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -161,8 +161,7 @@ def get_factura_emitida(invoice):
         'ClaveRegimenEspecialOTrascendencia':
             invoice.sii_out_clave_regimen_especial,
         'ImporteTotal': SIGN[invoice.rectificative_type] * invoice.amount_total,
-        'DescripcionOperacion':
-            invoice.journal_id.sii_description or invoice.journal_id.name,
+        'DescripcionOperacion': invoice.sii_description,
         'Contraparte': get_contraparte(invoice.partner_id, in_invoice=False),
         'TipoDesglose': get_factura_emitida_tipo_desglose(invoice)
     }
@@ -236,8 +235,7 @@ def get_factura_recibida(invoice):
         'ClaveRegimenEspecialOTrascendencia':
             invoice.sii_in_clave_regimen_especial,
         'ImporteTotal': SIGN[invoice.rectificative_type] * invoice.amount_total,
-        'DescripcionOperacion':
-            invoice.journal_id.sii_description or invoice.journal_id.name,
+        'DescripcionOperacion': invoice.sii_description,
         'Contraparte': get_contraparte(invoice.partner_id, in_invoice=True),
         'DesgloseFactura': desglose_factura,
         'CuotaDeducible': cuota_deducible,

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -94,6 +94,11 @@ with description('El XML Generado'):
                  ['ClaveRegimenEspecialOTrascendencia'])
             ))
 
+        with it('la descripción de la operación debe ser el de la factura'):
+            expect(
+                self.factura['FacturaExpedida']['DescripcionOperacion']
+            ).to(equal(self.invoice.sii_description))
+
         with it('el número de la factura debe ser el de la factura original'):
             expect(
                 self.factura['IDFactura']['NumSerieFacturaEmisor']

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -48,9 +48,8 @@ class Partner:
 
 
 class Journal:
-    def __init__(self, name, sii_description):
+    def __init__(self, name):
         self.name = name
-        self.sii_description = sii_description
 
 
 class FiscalPosition:
@@ -96,6 +95,7 @@ class Invoice:
                  rectificative_type,
                  fiscal_position,
                  invoice_line,
+                 sii_description,
                  sii_in_clave_regimen_especial,
                  sii_out_clave_regimen_especial,
                  origin_date_invoice,
@@ -116,6 +116,7 @@ class Invoice:
         self.fiscal_position = fiscal_position
         self.sii_registered = sii_registered
         self.origin = origin
+        self.sii_description = sii_description
         self.sii_in_clave_regimen_especial = sii_in_clave_regimen_especial
         self.sii_out_clave_regimen_especial = sii_out_clave_regimen_especial
         self.rectificative_type = rectificative_type
@@ -216,13 +217,13 @@ class DataGenerator:
         self.fiscal_position = FiscalPosition(
             name=u'Régimen Islas Canarias'
         )
+        self.sii_description = u'Descripción de operación estándar'
         self.sii_in_clave_regimen_especial = '01'
         self.sii_out_clave_regimen_especial = '01'
 
     def get_in_invoice(self):
         journal = Journal(
-            name=u'Factura de Energía Recibida',
-            sii_description=u'Descripción Facturas Recibidas'
+            name=u'Factura de Energía Recibida'
         )
 
         invoice = Invoice(
@@ -243,6 +244,7 @@ class DataGenerator:
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
             fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
             sii_in_clave_regimen_especial=self.sii_in_clave_regimen_especial,
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial
         )
@@ -250,8 +252,7 @@ class DataGenerator:
 
     def get_out_invoice(self):
         journal = Journal(
-            name=u'Factura de Energía Emitida',
-            sii_description=u'Descripción Facturas Emitidas'
+            name=u'Factura de Energía Emitida'
         )
 
         invoice = Invoice(
@@ -271,6 +272,7 @@ class DataGenerator:
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
             fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
             sii_in_clave_regimen_especial=self.sii_in_clave_regimen_especial,
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial
         )
@@ -278,8 +280,7 @@ class DataGenerator:
 
     def get_in_refund_invoice(self):
         journal = Journal(
-            name=u'Factura de Energía Rectificativa Recibida',
-            sii_description=u'Descripción Facturas Rectificativas Recibidas'
+            name=u'Factura de Energía Rectificativa Recibida'
         )
 
         invoice = Invoice(
@@ -300,6 +301,7 @@ class DataGenerator:
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
             fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
             sii_in_clave_regimen_especial=self.sii_in_clave_regimen_especial,
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial
         )
@@ -307,8 +309,7 @@ class DataGenerator:
 
     def get_out_refund_invoice(self):
         journal = Journal(
-            name=u'Factura de Energía Rectificativa Emitida',
-            sii_description=u'Descripción Facturas Rectificativas Emitidas'
+            name=u'Factura de Energía Rectificativa Emitida'
         )
 
         invoice = Invoice(
@@ -328,6 +329,7 @@ class DataGenerator:
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
             fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
             sii_in_clave_regimen_especial=self.sii_in_clave_regimen_especial,
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial
         )


### PR DESCRIPTION
Requires https://github.com/gisce/erp/pull/4813

This PR gets `sii_description` from invoice instead of getting it from `invoice.journal_id`