### PR TITLE
Refactor all partner VATs

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -348,7 +348,8 @@ def get_factura_recibida_dict(invoice, rectificativa=False):
 def refactor_nifs(invoice):
     for partner in (invoice.partner_id, invoice.company_id.partner_id):
         if partner.vat:
-            partner.vat = re.sub('^ES', '', partner.vat.upper())
+            # partner.vat = re.sub('^ES', '', partner.vat.upper())
+            partner.vat = partner.vat[2:]
 
 
 class SII(object):


### PR DESCRIPTION
This is to remove first two characters from partner VATs.

All VATs must start with country code or with 'PS'