### PR TITLE
Improve testing data consistency

### DIFF
--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -293,7 +293,7 @@ class DataGenerator:
         )
 
         rect_invoice = Invoice(
-            type='out_invoice',
+            type='in_invoice',
             journal_id=journal,
             rectificative_type='N',
             rectifying_id=False,


### PR DESCRIPTION
- Set invoice refunded `type` to `in_invoice` because it is refunded by an `in_refund`