### PR TITLE
Verify the SSL connexion using CA_BUNDLE from certifi library

### DIFF
--- a/sii/server.py
+++ b/sii/server.py
@@ -6,6 +6,7 @@ from requests import Session
 from zeep.exceptions import Fault
 from zeep.transports import Transport
 from zeep.helpers import serialize_object
+import certifi
 
 MAX_ID_CHECKS = 9999
 
@@ -81,7 +82,7 @@ class IDService(Service):
             wsdl = self.wsdl_files['ids_validator_v2']
         session = Session()
         session.cert = (self.certificate, self.key)
-        session.verify = False
+        session.verify = certifi.where()
         transport = Transport(session=session)
 
         client = Client(wsdl=wsdl, port_name=port_name, transport=transport,
@@ -120,7 +121,7 @@ class SiiService(Service):
     def create_service(self):
         session = Session()
         session.cert = (self.certificate, self.key)
-        session.verify = False
+        session.verify = certifi.where()
         transport = Transport(session=session)
         if self.invoice.type.startswith('out_'):
             config = self.out_inv_config.copy()


### PR DESCRIPTION
This uses a CA_BUNDLE (Certificate Authorities Bundle) composed by a group of root certificates and intermediate certificates to avoid "InsecureRequestWarning: Unverified HTTPS request is being made"