### PR TITLE
Expect result NO IDENTIFICADO - SIMILAR from AEAT

### DIFF
--- a/sii/server.py
+++ b/sii/server.py
@@ -61,7 +61,7 @@ class IDService(Service):
         invalid_ids = []
         if isinstance(partners, list):
             for partner in res:
-                if partner['Resultado'] == 'NO IDENTIFICADO':
+                if 'NO IDENTIFICADO' in partner['Resultado']:
                     invalid_ids.append(partner)
         else:
             if isinstance(res, Exception) and res.message == 'Codigo[-1].No identificado':


### PR DESCRIPTION
This is to ensure that all results  including "NO IDENTIFICADO" are treated as invalid when verifying a partner with its Name and NIF.