### PR TITLE
Ensure names are unidecoded

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -1,12 +1,11 @@
 # coding=utf-8
 import re
 from copy import deepcopy
-from utils import unidecode_str
 from decimal import Decimal, localcontext
 
 from sii import __SII_VERSION__
 from sii.models import invoices_record, invoices_deregister
-from sii.utils import COUNTRY_CODES
+from sii.utils import COUNTRY_CODES, unidecode_str
 
 SIGN = {'N': 1, 'R': 1, 'A': -1, 'B': -1, 'RA': 1, 'C': 1, 'G': 1}  # 'BRA': -1
 

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 import re
 from copy import deepcopy
-from unidecode import unidecode
+from utils import unidecode_str
 from decimal import Decimal, localcontext
 
 from sii import __SII_VERSION__
@@ -108,17 +108,6 @@ def get_iva_values(invoice, in_invoice, is_export=False, is_import=False):
         vals['importe_no_sujeto'] = invoice_total
 
     return vals
-
-
-def unidecode_str(s):
-    if type(s) is unicode:
-        res = unidecode(s)
-    elif type(s) is str:
-        res = unidecode(s.decode('utf-8'))
-    else:
-        res = unidecode(s)
-
-    return res
 
 
 def get_contraparte(partner, in_invoice):

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -110,9 +110,20 @@ def get_iva_values(invoice, in_invoice, is_export=False, is_import=False):
     return vals
 
 
+def unidecode_str(s):
+    if type(s) is unicode:
+        res = unidecode(s)
+    elif type(s) is str:
+        res = unidecode(s.decode('utf-8'))
+    else:
+        res = unidecode(s)
+
+    return res
+
+
 def get_contraparte(partner, in_invoice):
     vat_type = partner.sii_get_vat_type()
-    contraparte = {'NombreRazon': unidecode(partner.name)}
+    contraparte = {'NombreRazon': unidecode_str(partner.name)}
 
     partner_country = partner.country_id or partner.country
 
@@ -191,7 +202,7 @@ def get_factura_emitida_tipo_desglose(invoice):
                 }
         if iva_values['no_sujeta_a_iva']:
             fp = invoice.fiscal_position
-            if fp and 'islas canarias' in unidecode(fp.name.lower()):
+            if fp and 'islas canarias' in unidecode_str(fp.name.lower()):
                 desglose['NoSujeta'] = {
                     'ImporteTAIReglasLocalizacion': importe_no_sujeto
                 }
@@ -435,7 +446,7 @@ def get_header(invoice):
     cabecera = {
         'IDVersionSii': __SII_VERSION__,
         'Titular': {
-            'NombreRazon': invoice.company_id.partner_id.name,
+            'NombreRazon': unidecode_str(invoice.company_id.partner_id.name),
             'NIF': invoice.company_id.partner_id.vat
         },
         'TipoComunicacion': 'A0' if not invoice.sii_registered else 'A1'
@@ -622,7 +633,7 @@ def get_baja_factura_recibida_dict(invoice):
                 },
                 'IDFactura': {
                     'IDEmisorFactura': {
-                        'NombreRazon': invoice.partner_id.name,
+                        'NombreRazon': unidecode_str(invoice.partner_id.name),
                         'NIF': invoice.partner_id.vat
                     },
                     'NumSerieFacturaEmisor': invoice.origin,

--- a/sii/utils.py
+++ b/sii/utils.py
@@ -4,9 +4,7 @@ from unidecode import unidecode
 
 
 def unidecode_str(s):
-    if type(s) is unicode:
-        res = unidecode(s)
-    elif type(s) is str:
+    if isinstance(s, bytes):
         res = unidecode(s.decode('utf-8'))
     else:
         res = unidecode(s)

--- a/sii/utils.py
+++ b/sii/utils.py
@@ -1,5 +1,19 @@
 # -*- coding: UTF-8 -*-
 
+from unidecode import unidecode
+
+
+def unidecode_str(s):
+    if type(s) is unicode:
+        res = unidecode(s)
+    elif type(s) is str:
+        res = unidecode(s.decode('utf-8'))
+    else:
+        res = unidecode(s)
+
+    return res
+
+
 COUNTRY_CODES = {
     'AF': 'AFGANISTÁN',
     'AL': 'ALBANIA',

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -2,6 +2,7 @@
 
 from sii.resource import SII, SIIDeregister
 from sii.models.invoices_record import CRE_FACTURAS_EMITIDAS
+from sii.utils import unidecode_str
 from expects import *
 from datetime import datetime
 from spec.testing_data import DataGenerator
@@ -68,7 +69,9 @@ with description('El XML Generado'):
             with it('el nombre y apellidos deben ser los del titular'):
                 expect(
                     self.cabecera['Titular']['NombreRazon']
-                ).to(equal(self.invoice.company_id.partner_id.name))
+                ).to(equal(
+                    unidecode_str(self.invoice.company_id.partner_id.name))
+                )
 
     with description('en los datos comunes de una factura'):
         with before.all:
@@ -621,7 +624,9 @@ with description('El XML Generado en una baja de una factura emitida'):
             with it('el nombre y apellidos deben ser los del titular'):
                 expect(
                     self.cabecera['Titular']['NombreRazon']
-                ).to(equal(self.invoice.company_id.partner_id.name))
+                ).to(equal(
+                    unidecode_str(self.invoice.company_id.partner_id.name))
+                )
 
     with description('en la baja de una factura'):
         with before.all:
@@ -704,7 +709,9 @@ with description('El XML Generado en una baja de una factura recibida'):
             with it('el nombre y apellidos deben ser los del titular'):
                 expect(
                     self.cabecera['Titular']['NombreRazon']
-                ).to(equal(self.invoice.company_id.partner_id.name))
+                ).to(equal(
+                    unidecode_str(self.invoice.company_id.partner_id.name))
+                )
 
     with description('en la baja de una factura'):
         with before.all:
@@ -739,7 +746,7 @@ with description('El XML Generado en una baja de una factura recibida'):
                 expect(
                     self.factura['IDEmisorFactura']['NombreRazon']
                 ).to(equal(
-                    self.invoice.partner_id.name
+                    unidecode_str(self.invoice.partner_id.name)
                 ))
 
             with it('el NIF del emisor de la factura es correcto'):


### PR DESCRIPTION
Expect all names from partners are unidecoded in order to remove special characters (ç, ñ, à, á, é, ...)