### PR TITLE
Permitir al campo IDEmisorFactura tener IDOtro para Facturas Recibidas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 marshmallow>=2.13.5
 zeep
 unidecode
+python-stdnum

--- a/sii/models/invoices_deregister.py
+++ b/sii/models/invoices_deregister.py
@@ -4,7 +4,8 @@ from __future__ import absolute_import
 from marshmallow import fields, ValidationError
 from sii import __SII_VERSION__
 from .invoices_record import (
-    MySchema, DateString, CustomStringField, Titular, NIF, PERIODO_VALUES
+    MySchema, DateString, CustomStringField, Titular, Partner, NIF,
+    PERIODO_VALUES
 )
 
 
@@ -46,8 +47,15 @@ class IdentificacionFacturaEmitida(IdentificacionFactura):
     IDEmisorFactura = fields.Nested(NIF, required=True)
 
 
+class EmisorBajaFacturaRecibida(Titular, Partner):
+
+    @staticmethod
+    def get_atleast_one_of():
+        return ['NIF', 'IDOtro']
+
+
 class IdentificacionFacturaRecibida(IdentificacionFactura):
-    IDEmisorFactura = fields.Nested(Titular, required=True)
+    IDEmisorFactura = fields.Nested(EmisorBajaFacturaRecibida, required=True)
 
 
 class PeriodoImpositivo(MySchema):

--- a/sii/models/invoices_record.py
+++ b/sii/models/invoices_record.py
@@ -353,8 +353,6 @@ class EmisorFactura(NIF):
     def get_nif_field_name():
         return 'NIF del Emisor de la factura'
 
-    pass
-
 
 class IdentificacionFactura(MySchema):
     IDEmisorFactura = fields.Nested(EmisorFactura, required=True)
@@ -452,14 +450,15 @@ class TipoDesglose(MySchema):  # TODO obligatorio uno de los dos pero sólo pued
     DesgloseTipoOperacion = fields.Nested(DesgloseTipoOperacion)
 
 
-class Contraparte(Titular):
+class IDOtro(NIF):
+    IDOtro = fields.Nested(IDOtro)
+
+
+class Contraparte(Titular, IDOtro):
 
     @staticmethod
     def get_nif_field_name():
-        return 'NIF del Receptor de la factura'
-
-    IDOtro = fields.Nested(IDOtro)
-    pass
+        return 'NIF de la Contraparte de la factura'
 
 
 class ImporteRectificacion(MySchema):
@@ -557,6 +556,14 @@ class DetalleFacturaEmitida(DetalleFactura):
         )
 
 
+class EmisorFacturaRecibida(EmisorFactura, IDOtro):
+    pass
+
+
+class IdentificacionFacturaRecibida(IdentificacionFactura):
+    IDEmisorFactura = fields.Nested(EmisorFacturaRecibida, required=True)
+
+
 class FacturaEmitida(Factura):
     # Campos específicos para facturas emitidas
     FacturaExpedida = fields.Nested(DetalleFacturaEmitida, required=True)
@@ -643,6 +650,7 @@ class DetalleFacturaRecibida(DetalleFactura):
 
 class FacturaRecibida(Factura):
     # Campos específicos para facturas recibidas
+    IDFactura = fields.Nested(IdentificacionFacturaRecibida, required=True)
     FacturaRecibida = fields.Nested(DetalleFacturaRecibida, required=True)
 
 

--- a/sii/models/invoices_record.py
+++ b/sii/models/invoices_record.py
@@ -450,11 +450,11 @@ class TipoDesglose(MySchema):  # TODO obligatorio uno de los dos pero sólo pued
     DesgloseTipoOperacion = fields.Nested(DesgloseTipoOperacion)
 
 
-class IDOtro(NIF):
+class Partner(NIF):
     IDOtro = fields.Nested(IDOtro)
 
 
-class Contraparte(Titular, IDOtro):
+class Contraparte(Titular, Partner):
 
     @staticmethod
     def get_nif_field_name():

--- a/sii/models/invoices_record.py
+++ b/sii/models/invoices_record.py
@@ -556,8 +556,11 @@ class DetalleFacturaEmitida(DetalleFactura):
         )
 
 
-class EmisorFacturaRecibida(EmisorFactura, IDOtro):
-    pass
+class EmisorFacturaRecibida(EmisorFactura, Partner):
+
+    @staticmethod
+    def get_atleast_one_of():
+        return ['NIF', 'IDOtro']
 
 
 class IdentificacionFacturaRecibida(IdentificacionFactura):

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -485,9 +485,9 @@ def get_factura_recibida_dict(invoice,
                     'Periodo': invoice.period_id.name[0:2]
                 },
                 'IDFactura': {
-                    'IDEmisorFactura': {
-                        'NIF': invoice.partner_id.vat
-                    },
+                    'IDEmisorFactura': get_partner_info(
+                        invoice.partner_id, in_invoice=False
+                    ),
                     'NumSerieFacturaEmisor': invoice.origin,
                     'FechaExpedicionFacturaEmisor': invoice.origin_date_invoice
                 },
@@ -624,10 +624,9 @@ def get_baja_factura_recibida_dict(invoice):
                     'Periodo': invoice.period_id.name[0:2]
                 },
                 'IDFactura': {
-                    'IDEmisorFactura': {
-                        'NombreRazon': unidecode_str(invoice.partner_id.name),
-                        'NIF': invoice.partner_id.vat
-                    },
+                    'IDEmisorFactura': get_partner_info(
+                        invoice.partner_id, in_invoice=True, nombre_razon=True
+                    ),
                     'NumSerieFacturaEmisor': invoice.origin,
                     'FechaExpedicionFacturaEmisor': invoice.origin_date_invoice
                 }

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -5,7 +5,7 @@ from decimal import Decimal, localcontext
 
 from sii import __SII_VERSION__
 from sii.models import invoices_record, invoices_deregister
-from sii.utils import COUNTRY_CODES, unidecode_str
+from sii.utils import COUNTRY_CODES, unidecode_str, VAT
 
 SIGN = {'N': 1, 'R': 1, 'A': -1, 'B': -1, 'RA': 1, 'C': 1, 'G': 1}  # 'BRA': -1
 
@@ -123,15 +123,15 @@ def get_partner_info(partner, in_invoice, nombre_razon=False):
             contraparte['IDOtro'] = {
                 'CodigoPais': partner_country.code,
                 'IDType': '07',
-                'ID': partner.vat
+                'ID': VAT.clean_vat(partner.vat)
             }
         else:
-            contraparte['NIF'] = partner.vat
+            contraparte['NIF'] = VAT.clean_vat(partner.vat)
     else:
         contraparte['IDOtro'] = {
             'CodigoPais': partner_country.code,
             'IDType': vat_type,
-            'ID': partner.vat
+            'ID': VAT.clean_vat(partner.vat)
         }
 
     return contraparte
@@ -202,7 +202,7 @@ def get_factura_emitida_tipo_desglose(invoice):
                     'ImportePorArticulos7_14_Otros': importe_no_sujeto
                 }
 
-        partner_vat = invoice.partner_id.vat
+        partner_vat = VAT.clean_vat(invoice.partner_id.vat)
         partner_vat_starts_with_n = (
             partner_vat and partner_vat.upper().startswith('N')
         )
@@ -439,7 +439,7 @@ def get_header(invoice):
         'IDVersionSii': __SII_VERSION__,
         'Titular': {
             'NombreRazon': unidecode_str(invoice.company_id.partner_id.name),
-            'NIF': invoice.company_id.partner_id.vat
+            'NIF': VAT.clean_vat(invoice.company_id.partner_id.vat)
         },
         'TipoComunicacion': 'A0' if not invoice.sii_registered else 'A1'
     }
@@ -459,7 +459,7 @@ def get_factura_emitida_dict(invoice,
                 },
                 'IDFactura': {
                     'IDEmisorFactura': {
-                        'NIF': invoice.company_id.partner_id.vat
+                        'NIF': VAT.clean_vat(invoice.company_id.partner_id.vat)
                     },
                     'NumSerieFacturaEmisor': invoice.number,
                     'FechaExpedicionFacturaEmisor': invoice.date_invoice
@@ -652,7 +652,7 @@ def get_baja_factura_emitida_dict(invoice):
                 },
                 'IDFactura': {
                     'IDEmisorFactura': {
-                        'NIF': invoice.company_id.partner_id.vat
+                        'NIF': VAT.clean_vat(invoice.company_id.partner_id.vat)
                     },
                     'NumSerieFacturaEmisor': invoice.number,
                     'FechaExpedicionFacturaEmisor': invoice.date_invoice

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -501,16 +501,6 @@ def get_factura_recibida_dict(invoice,
     return obj
 
 
-def refactor_nifs(invoice):
-    for partner in (invoice.partner_id, invoice.company_id.partner_id):
-        partner_vat = partner.vat
-        if partner_vat and len(partner_vat) >= 2:
-            country_code = partner_vat[:2].upper()
-            if country_code in COUNTRY_CODES or country_code == 'PS':
-                # partner.vat = re.sub('^ES', '', partner.vat.upper())
-                partner.vat = partner_vat[2:]
-
-
 def refactor_decimals(invoice):
     def transform(f):
         return Decimal(str(f))
@@ -540,7 +530,6 @@ def refactor_decimals(invoice):
 class SII(object):
     def __init__(self, invoice):
         self.invoice = invoice
-        refactor_nifs(self.invoice)
         refactor_decimals(self.invoice)
         tipo_rectificativa = invoice.rectificative_type
         rectificativa_sustitucion_opcion_1 = tipo_rectificativa == 'RA'

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -109,9 +109,12 @@ def get_iva_values(invoice, in_invoice, is_export=False, is_import=False):
     return vals
 
 
-def get_contraparte(partner, in_invoice):
+def get_partner_info(partner, in_invoice, nombre_razon=False):
     vat_type = partner.sii_get_vat_type()
-    contraparte = {'NombreRazon': unidecode_str(partner.name)}
+    contraparte = {}
+
+    if nombre_razon:
+        contraparte['NombreRazon'] = unidecode_str(partner.name)
 
     partner_country = partner.country_id or partner.country
 
@@ -293,7 +296,8 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
             invoice.sii_out_clave_regimen_especial,
         'ImporteTotal': get_invoice_sign(invoice) * invoice.amount_total,
         'DescripcionOperacion': invoice.sii_description,
-        'Contraparte': get_contraparte(invoice.partner_id, in_invoice=False),
+        'Contraparte': get_partner_info(
+            invoice.partner_id, in_invoice=False, nombre_razon=True),
         'TipoDesglose': get_factura_emitida_tipo_desglose(invoice)
     }
 
@@ -398,8 +402,8 @@ def get_factura_recibida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
             invoice.sii_in_clave_regimen_especial,
         'ImporteTotal': importe_total,
         'DescripcionOperacion': invoice.sii_description,
-        'Contraparte': get_contraparte(
-            invoice.partner_id, in_invoice=in_invoice),
+        'Contraparte': get_partner_info(
+            invoice.partner_id, in_invoice=in_invoice, nombre_razon=True),
         'DesgloseFactura': desglose_factura,
         'CuotaDeducible': cuota_deducible,
         'FechaRegContable': invoice.date_invoice

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -486,7 +486,7 @@ def get_factura_recibida_dict(invoice,
                 },
                 'IDFactura': {
                     'IDEmisorFactura': get_partner_info(
-                        invoice.partner_id, in_invoice=False
+                        invoice.partner_id, in_invoice=True
                     ),
                     'NumSerieFacturaEmisor': invoice.origin,
                     'FechaExpedicionFacturaEmisor': invoice.origin_date_invoice

--- a/sii/utils.py
+++ b/sii/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: UTF-8 -*-
 
 from unidecode import unidecode
+from stdnum import es
 
 
 def unidecode_str(s):
@@ -10,6 +11,82 @@ def unidecode_str(s):
         res = unidecode(s)
 
     return res
+
+
+class VAT:
+    def __init__(self, vat):
+        self.vat = vat
+
+    @staticmethod
+    def clean_vat(vat):
+        """
+        Returns the vat without the country code in the first two characters or
+        without the "PS" that indicates it is a passport
+        """
+        country_code = len(vat) >= 2 and vat[:2].upper()
+        if country_code in COUNTRY_CODES or country_code == 'PS':
+            return vat[2:]
+        return vat
+
+    @staticmethod
+    def is_dni_vat(vat):
+        """ Returns True if vat is DNI (Spanish VAT)"""
+        country_code = len(vat) >= 2 and vat[:2]
+        if country_code in COUNTRY_CODES or country_code == 'PS':
+            vat = vat[2:]
+        if country_code == 'ES':
+            return es.dni.is_valid(vat)
+        return False
+
+    @staticmethod
+    def is_enterprise_vat(vat):
+        """ Returns True if vat is enterprise"""
+        country_code = len(vat) >= 2 and vat[:2]
+        if country_code in COUNTRY_CODES or country_code == 'PS':
+            vat = vat[2:]
+        if country_code == 'ES':
+            return es.cif.is_valid(vat)
+        return False
+
+    @staticmethod
+    def is_nie_vat(vat):
+        """ Returns True if vat is NIE (foreigner's document)"""
+        country_code = len(vat) >= 2 and vat[:2]
+        if country_code in COUNTRY_CODES or country_code == 'PS':
+            vat = vat[2:]
+        if country_code == 'ES':
+            return es.nie.is_valid(vat)
+        return False
+
+    @staticmethod
+    def is_official_identification_document(vat):
+        """ Returns True if vat is a foreign official identification document"""
+        country_code = len(vat) >= 2 and vat[:2]
+        if country_code != 'ES':
+            return country_code in COUNTRY_CODES
+        return False
+
+    @staticmethod
+    def is_passport(vat):
+        """ Returns True if vat is passport"""
+        if len(vat) >= 2:
+            return vat[:2] == 'PS'
+        return False
+
+    @staticmethod
+    def sii_get_vat_type(vat):
+        partner_vat = vat
+        is_nif = VAT.is_dni_vat(partner_vat)
+        is_nie = VAT.is_nie_vat(partner_vat)
+        is_enterprise = VAT.is_enterprise_vat(partner_vat)
+        if is_nif or is_nie or is_enterprise:
+            return '02'
+        elif VAT.is_passport(partner_vat):
+            return '03'
+        elif VAT.is_official_identification_document(partner_vat):
+            return '04'
+        else:
+            return '02'
 
 
 COUNTRY_CODES = {

--- a/spec/manual_test.py
+++ b/spec/manual_test.py
@@ -9,19 +9,23 @@ import os
 from pprintpp import pprint, pformat
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)
 
 certificate_path = os.environ['CERTIFICATE_PATH']
 key_path = os.environ['KEY_PATH']
 current_date = date.strftime(date.today(), '%Y-%m-%d')
 
-data_gen = DataGenerator(contraparte_registered=False)
+data_gen = DataGenerator(
+    contraparte_registered=False,
+    invoice_registered=True
+)
 data_gen.invoice_number = '-{}'.format(current_date)
 out_invoice = data_gen.get_out_invoice()
 in_invoice = data_gen.get_in_invoice()
 
 # CONFIGURATION VARIABLES
 invoice = in_invoice
+invoice.partner_id.country_id.code = os.environ['COUNTRY_CODE']
 register_invoice = True
 deregister_invoice = True
 

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -367,7 +367,9 @@ with description('El XML Generado'):
                 with before.all:
                     new_data_gen = DataGenerator(contraparte_registered=False)
                     self.in_invoice = new_data_gen.get_in_invoice()
-                    self.nif_emisor = self.in_invoice.partner_id.vat[2:]
+                    # Valid French TVA FR23334175221
+                    self.in_invoice.partner_id.country_id.code = 'FR'
+                    self.in_invoice.partner_id.vat = 'FR23334175221'
 
                     in_invoice_obj = SII(self.in_invoice).generate_object()
                     self.emisor_factura = (
@@ -377,17 +379,20 @@ with description('El XML Generado'):
                     )
 
                 with it('el ID debe ser el NIF del emisor'):
+                    nif_emisor = self.in_invoice.partner_id.vat[2:]
                     expect(
                         self.emisor_factura['IDOtro']['ID']
-                    ).to(equal(self.nif_emisor))
+                    ).to(equal(nif_emisor))
 
-                with it('el IDType debe ser "07"'):
-                    expect(self.emisor_factura['IDOtro']['IDType']).to(equal('07'))
+                with it('el IDType debe ser "04"'):
+                    expect(
+                        self.emisor_factura['IDOtro']['IDType']
+                    ).to(equal('04'))
 
-                with it('el CodigoPais debe ser "ES"'):
+                with it('el CodigoPais debe ser "FR"'):
                     expect(
                         self.emisor_factura['IDOtro']['CodigoPais']
-                    ).to(equal('ES'))
+                    ).to(equal('FR'))
 
         with context('en los detalles del IVA'):
             with it('el detalle de DesgloseIVA debe ser la original'):

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -2,7 +2,7 @@
 
 from sii.resource import SII, SIIDeregister
 from sii.models.invoices_record import CRE_FACTURAS_EMITIDAS
-from sii.utils import unidecode_str
+from sii.utils import unidecode_str, VAT
 from expects import *
 from datetime import datetime
 from spec.testing_data import DataGenerator
@@ -66,7 +66,9 @@ with description('El XML Generado'):
             with it('el nif deben ser los del titular'):
                 expect(
                     self.cabecera['Titular']['NIF']
-                ).to(equal(self.invoice.company_id.partner_id.vat))
+                ).to(equal(
+                    VAT.clean_vat(self.invoice.company_id.partner_id.vat)
+                ))
 
             with it('el nombre y apellidos deben ser los del titular'):
                 expect(
@@ -649,7 +651,9 @@ with description('El XML Generado en una baja de una factura emitida'):
             with it('el nif deben ser los del titular'):
                 expect(
                     self.cabecera['Titular']['NIF']
-                ).to(equal(self.invoice.company_id.partner_id.vat))
+                ).to(equal(
+                    VAT.clean_vat(self.invoice.company_id.partner_id.vat)
+                ))
 
             with it('el nombre y apellidos deben ser los del titular'):
                 expect(
@@ -691,7 +695,7 @@ with description('El XML Generado en una baja de una factura emitida'):
                 expect(
                     self.factura['IDEmisorFactura']['NIF']
                 ).to(equal(
-                    self.invoice.company_id.partner_id.vat
+                    VAT.clean_vat(self.invoice.company_id.partner_id.vat)
                 ))
 
             with it('el número de factura es correcto'):
@@ -734,7 +738,9 @@ with description('El XML Generado en una baja de una factura recibida'):
             with it('el nif deben ser los del titular'):
                 expect(
                     self.cabecera['Titular']['NIF']
-                ).to(equal(self.invoice.company_id.partner_id.vat))
+                ).to(equal(
+                    VAT.clean_vat(self.invoice.company_id.partner_id.vat)
+                ))
 
             with it('el nombre y apellidos deben ser los del titular'):
                 expect(
@@ -783,7 +789,7 @@ with description('El XML Generado en una baja de una factura recibida'):
                 expect(
                     self.factura['IDEmisorFactura']['NIF']
                 ).to(equal(
-                    self.invoice.partner_id.vat
+                    VAT.clean_vat(self.invoice.partner_id.vat)
                 ))
 
             with it('el número de factura es correcto'):

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -368,7 +368,7 @@ with description('El XML Generado'):
                     self.nif_emisor = self.in_invoice.partner_id.vat[2:]
 
                     in_invoice_obj = SII(self.in_invoice).generate_object()
-                    self.contraparte = (
+                    self.emisor_factura = (
                         in_invoice_obj['SuministroLRFacturasRecibidas']
                         ['RegistroLRFacturasRecibidas']['IDFactura']
                         ['IDEmisorFactura']
@@ -376,15 +376,15 @@ with description('El XML Generado'):
 
                 with it('el ID debe ser el NIF del emisor'):
                     expect(
-                        self.contraparte['IDOtro']['ID']
+                        self.emisor_factura['IDOtro']['ID']
                     ).to(equal(self.nif_emisor))
 
                 with it('el IDType debe ser "07"'):
-                    expect(self.contraparte['IDOtro']['IDType']).to(equal('07'))
+                    expect(self.emisor_factura['IDOtro']['IDType']).to(equal('07'))
 
                 with it('el CodigoPais debe ser "ES"'):
                     expect(
-                        self.contraparte['IDOtro']['CodigoPais']
+                        self.emisor_factura['IDOtro']['CodigoPais']
                     ).to(equal('ES'))
 
         with context('en los detalles del IVA'):

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -359,6 +359,34 @@ with description('El XML Generado'):
                 ['RegistroLRFacturasRecibidas']
             )
 
+        with context('en los datos del emisor de la factura'):
+
+            with context('si no está registrado en la AEAT'):
+                with before.all:
+                    new_data_gen = DataGenerator(contraparte_registered=False)
+                    self.in_invoice = new_data_gen.get_in_invoice()
+                    self.nif_emisor = self.in_invoice.partner_id.vat[2:]
+
+                    in_invoice_obj = SII(self.in_invoice).generate_object()
+                    self.contraparte = (
+                        in_invoice_obj['SuministroLRFacturasRecibidas']
+                        ['RegistroLRFacturasRecibidas']['IDFactura']
+                        ['IDEmisorFactura']
+                    )
+
+                with it('el ID debe ser el NIF del emisor'):
+                    expect(
+                        self.contraparte['IDOtro']['ID']
+                    ).to(equal(self.nif_emisor))
+
+                with it('el IDType debe ser "07"'):
+                    expect(self.contraparte['IDOtro']['IDType']).to(equal('07'))
+
+                with it('el CodigoPais debe ser "ES"'):
+                    expect(
+                        self.contraparte['IDOtro']['CodigoPais']
+                    ).to(equal('ES'))
+
         with context('en los detalles del IVA'):
             with it('el detalle de DesgloseIVA debe ser la original'):
                 detalle_iva_desglose_iva = (

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -2,6 +2,7 @@
 
 import os
 import random
+from sii.utils import VAT
 
 
 class Period:
@@ -44,7 +45,7 @@ class Partner:
         self.aeat_registered = aeat_registered
 
     def sii_get_vat_type(self):
-        return '02'
+        return VAT.sii_get_vat_type(self.vat)
 
 
 class Journal:


### PR DESCRIPTION
Esta Pull Request añade:

- [x] Tests para facturas de proveedor no registrados a la AEAT para que tengan el campo IDOtro
- [x] Adapta los modelos para permitir el campo IDOtro en el campo IDEmisorFactura de una Factura Recibida
- [x] Adapta los modelos para permitir el campo IDOtro en el campo IDEmisorFactura de una Baja de Factura Recibida
- [x] Renombra la función `get_contraparte` a `get_partner_info`
- [x] Añadir funciones de VAT para obtener el tipo de VAT según el SII en `utils`
- [x] Añade `python-stdnum` a los requisitos