### PR TITLE
No enviar parte no sujeta a IVA en facturas emitidas

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -192,16 +192,6 @@ def get_factura_emitida_tipo_desglose(invoice):
                         'DetalleIVA': detalle_iva
                     }
                 }
-        if iva_values['no_sujeta_a_iva']:
-            fp = invoice.fiscal_position
-            if fp and 'islas canarias' in unidecode_str(fp.name.lower()):
-                desglose['NoSujeta'] = {
-                    'ImporteTAIReglasLocalizacion': importe_no_sujeto
-                }
-            else:
-                desglose['NoSujeta'] = {
-                    'ImportePorArticulos7_14_Otros': importe_no_sujeto
-                }
 
         partner_vat = VAT.clean_vat(invoice.partner_id.vat)
         partner_vat_starts_with_n = (


### PR DESCRIPTION
## Problema

- Desde un proveedor P se informa como factura emitida con los siguientes datos:
    - Base Imponible del IVA: 77.02
    - Cuota Repercutida: 16.17
    - Importe no sujeto a IVA: 18.53
    - Total de la factura: 111.72 (si sumamos 77,02 + 16,17 + 18,53 nos sale esta cifra)
- Desde un cliente C se informa como factura recibida con los siguientes datos:
    - Base Imponible del IVA: 77.02
    - Cuota Soportada: 16.17
    - Total de la factura: 111.72 (si sumamos 77,02 + 16,17 no nos da el total)

En la página de consulta de facturas de la AEAT tanto para el proveedor P como para el cliente C aparece la factura con estado "Parcialmente contrastada" (indica que los criterios de contraste no coinciden según [la página de la AEAT](http://www.agenciatributaria.es/AEAT.internet/Inicio/Ayuda/Modelos__Procedimientos_y_Servicios/Ayuda_P_G417____IVA__Llevanza_de_libros_registro__SII_/Informacion_general/Preguntas_frecuentes/2__Registro__Cuestiones_comunes/2_45__Como_se_realiza_el_proceso_de_contraste_de_facturas_.shtml)).

Si el proveedor P realiza una modificación y no informa la parte no sujeta a IVA automáticamente aparece como "Contrastada", puesto que los criterios de contraste coinciden.

## Solución

Se deja de informar la parte no sujeta a IVA para las facturas emitidas.