### PR TITLE
Corregir envío de líneas de Facturas Recibidas sin impuesto

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -86,14 +86,10 @@ def get_iva_values(invoice, in_invoice, is_export=False, is_import=False):
                     'TipoImpositivo': tipo_impositivo,
                     'CuotaRepercutida': cuota
                 }
-                if vals['inversion_sujeto_pasivo']:
-                    vals['inversion_sujeto_pasivo'].append(new_value)
-                else:
-                    vals['inversion_sujeto_pasivo'] = [new_value]
+                vals['inversion_sujeto_pasivo'].append(new_value)
             # IVA 0% Exportaciones y IVA 0% Importaciones tienen amount 0 y se
             # detectan como IVA exento
-            elif (not is_export and not is_import
-                  and is_iva_exento and not in_invoice):
+            elif not is_export and not is_import and is_iva_exento:
                 vals['iva_exento'] = True
                 vals['detalle_iva_exento']['BaseImponible'] += inv_tax.base
             else:
@@ -121,6 +117,13 @@ def get_iva_values(invoice, in_invoice, is_export=False, is_import=False):
     if invoice_total != 0:
         vals['no_sujeta_a_iva'] = True
         vals['importe_no_sujeto'] = invoice_total
+        if in_invoice:
+            new_value = {
+                'BaseImponible': vals['importe_no_sujeto'],
+                'TipoImpositivo': 0,
+                'CuotaSoportada': 0
+            }
+            vals['detalle_iva'].append(new_value)
 
     return vals
 

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -111,7 +111,7 @@ def get_iva_values(invoice, in_invoice, is_export=False, is_import=False):
                     iva_values[tipo_impositivo] = iva
                 vals['iva_no_exento'] = True
 
-    vals['detalle_iva'] = iva_values.values()
+    vals['detalle_iva'] = list(iva_values.values())
 
     invoice_total = round(invoice_total, 2)
     if invoice_total != 0:

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -462,7 +462,7 @@ with description('El XML Generado'):
                     ).to(equal('FR'))
 
         with context('en los detalles del IVA'):
-            with it('el detalle de DesgloseIVA debe ser la original'):
+            with before.all:
                 detalle_iva_desglose_iva = (
                     self.factura_recibida['FacturaRecibida']['DesgloseFactura']
                     ['DesgloseIVA']['DetalleIVA']
@@ -471,6 +471,7 @@ with description('El XML Generado'):
                     detalle_iva_desglose_iva
                 )
 
+            with it('el detalle de DesgloseIVA debe ser la original'):
                 expect(
                     self.grouped_detalle_iva[21.0]['BaseImponible']
                 ).to(equal(
@@ -487,6 +488,8 @@ with description('El XML Generado'):
                     self.in_invoice.tax_line[0].tax_id.amount * 100
                 ))
 
+            with _it('el detalle de DesgloseIVA para importe no sujeto a '
+                     'impuesto debe ser correcto'):
                 expect(
                     self.grouped_detalle_iva[0.0]['BaseImponible']
                 ).to(equal(

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -490,18 +490,14 @@ with description('El XML Generado'):
                 expect(
                     self.grouped_detalle_iva[0.0]['BaseImponible']
                 ).to(equal(
-                    self.in_invoice.tax_line[3].base
+                    self.in_invoice.invoice_line[5].price_subtotal
                 ))
                 expect(
                     self.grouped_detalle_iva[0.0]['CuotaSoportada']
-                ).to(equal(
-                    self.in_invoice.tax_line[3].tax_amount
-                ))
+                ).to(equal(0))
                 expect(
                     self.grouped_detalle_iva[0.0]['TipoImpositivo']
-                ).to(equal(
-                    self.in_invoice.tax_line[3].tax_id.amount * 100
-                ))
+                ).to(equal(0))
 
         with context('si es una importación'):
             with before.all:

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -26,7 +26,8 @@ class DataGenerator:
             InvoiceLine(price_subtotal=800, invoice_line_tax_id=[tax_ibi]),
             InvoiceLine(
                 price_subtotal=1600, invoice_line_tax_id=[tax_iva_exento]
-            )
+            ),
+            InvoiceLine(price_subtotal=3200, invoice_line_tax_id=[])
         ]
 
         base_iva_21 = sum(


### PR DESCRIPTION
Enviar parte no sujeta a impuestos en facturas recibidas como una línea de IVA con tipo impositivo 0%