### PR TITLE
Utilizar la información fiscal de la factura siempre que esta esté  disponible antes que la información del partner

### DIFF
--- a/sii/models/basic_models.py
+++ b/sii/models/basic_models.py
@@ -100,11 +100,19 @@ class Invoice:
                  sii_in_clave_regimen_especial=None,
                  sii_out_clave_regimen_especial=None,
                  origin_date_invoice=None,
-                 origin=None):
+                 origin=None,
+                 fiscal_info=False,
+                 fiscal_name=None,
+                 fiscal_vat=None):
         self.journal_id = journal_id
         self.number = number
         self.type = invoice_type
         self.partner_id = partner_id
+        if fiscal_info:
+            if fiscal_name:
+                self.fiscal_name = fiscal_name
+            if fiscal_vat:
+                self.fiscal_vat = fiscal_vat
         self.address_contact_id = address_contact_id
         self.company_id = company_id
         self.period_id = period_id

--- a/sii/models/basic_models.py
+++ b/sii/models/basic_models.py
@@ -101,18 +101,16 @@ class Invoice:
                  sii_out_clave_regimen_especial=None,
                  origin_date_invoice=None,
                  origin=None,
-                 fiscal_info=False,
                  fiscal_name=None,
                  fiscal_vat=None):
         self.journal_id = journal_id
         self.number = number
         self.type = invoice_type
         self.partner_id = partner_id
-        if fiscal_info:
-            if fiscal_name:
-                self.fiscal_name = fiscal_name
-            if fiscal_vat:
-                self.fiscal_vat = fiscal_vat
+        if fiscal_name:
+            self.fiscal_name = fiscal_name
+        if fiscal_vat:
+            self.fiscal_vat = fiscal_vat
         self.address_contact_id = address_contact_id
         self.company_id = company_id
         self.period_id = period_id

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -359,6 +359,8 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
 
     rectificativa = rect_sust_opc1 or rect_sust_opc2
 
+    fiscal_partner = FiscalPartner(invoice)
+
     factura_expedida = {
         'TipoFactura': 'R4' if rectificativa else 'F1',
         'ClaveRegimenEspecialOTrascendencia':
@@ -366,7 +368,7 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
         'ImporteTotal': get_invoice_sign(invoice) * invoice.amount_total,
         'DescripcionOperacion': invoice.sii_description,
         'Contraparte': get_partner_info(
-            invoice.partner_id, in_invoice=False, nombre_razon=True),
+            fiscal_partner, in_invoice=False, nombre_razon=True),
         'TipoDesglose': get_factura_emitida_tipo_desglose(invoice)
     }
 
@@ -479,7 +481,7 @@ def get_factura_recibida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
         cuota_deducible = 0  # Cuota deducible: Etiqueta con 0
 
     rectificativa = rect_sust_opc1 or rect_sust_opc2
-
+    fiscal_partner = FiscalPartner(invoice)
     factura_recibida = {
         'TipoFactura': 'R4' if rectificativa else 'F1',
         'ClaveRegimenEspecialOTrascendencia':
@@ -487,7 +489,7 @@ def get_factura_recibida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
         'ImporteTotal': importe_total,
         'DescripcionOperacion': invoice.sii_description,
         'Contraparte': get_partner_info(
-            invoice.partner_id, in_invoice=in_invoice, nombre_razon=True),
+            fiscal_partner, in_invoice=in_invoice, nombre_razon=True),
         'DesgloseFactura': desglose_factura,
         'CuotaDeducible': cuota_deducible,
         'FechaRegContable': fecha_reg_contable
@@ -560,6 +562,7 @@ def get_factura_emitida_dict(invoice,
 
 def get_factura_recibida_dict(invoice,
                               rect_sust_opc1=False, rect_sust_opc2=False):
+    fiscal_partner = FiscalPartner(invoice)
     obj = {
         'SuministroLRFacturasRecibidas': {
             'Cabecera': get_header(invoice),
@@ -570,7 +573,7 @@ def get_factura_recibida_dict(invoice,
                 },
                 'IDFactura': {
                     'IDEmisorFactura': get_partner_info(
-                        invoice.partner_id, in_invoice=True
+                        fiscal_partner, in_invoice=True
                     ),
                     'NumSerieFacturaEmisor': invoice.origin,
                     'FechaExpedicionFacturaEmisor': invoice.origin_date_invoice
@@ -687,7 +690,7 @@ def get_baja_factura_recibida_dict(invoice):
 
     cabecera = get_header(invoice)
     cabecera.pop('TipoComunicacion')
-
+    fiscal_partner = FiscalPartner(invoice)
     obj = {
         'BajaLRFacturasRecibidas': {
             'Cabecera': cabecera,
@@ -698,7 +701,7 @@ def get_baja_factura_recibida_dict(invoice):
                 },
                 'IDFactura': {
                     'IDEmisorFactura': get_partner_info(
-                        invoice.partner_id, in_invoice=True, nombre_razon=True
+                        fiscal_partner, in_invoice=True, nombre_razon=True
                     ),
                     'NumSerieFacturaEmisor': invoice.origin,
                     'FechaExpedicionFacturaEmisor': invoice.origin_date_invoice

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 import re
+import warnings
 from decimal import Decimal, localcontext
 
 from sii import __SII_VERSION__
@@ -770,8 +771,7 @@ class SIIDeregister(SII):
                 )
             )
 
-    def validate_deregister_invoice(self):
-
+    def validate_invoice(self):
         res = {}
 
         errors = self.invoice_deregister_model.validate(
@@ -786,9 +786,8 @@ class SIIDeregister(SII):
 
         return res
 
-    def generate_deregister_object(self):
-
-        validation_values = self.validate_deregister_invoice()
+    def generate_object(self):
+        validation_values = self.validate_invoice()
         if not validation_values['successful']:
             raise Exception(
                 'Errors were found while trying to validate the data:',

--- a/sii/server.py
+++ b/sii/server.py
@@ -204,7 +204,7 @@ class SiiDeregisterService(SiiService):
 
     def get_msg(self):
         dict_from_marsh = (
-            SIIDeregister(self.invoice).generate_deregister_object()
+            SIIDeregister(self.invoice).generate_object()
         )
         res_header = res_invoice = None
         if self.invoice.type.startswith('out_'):
@@ -227,7 +227,7 @@ class SiiDeregisterService(SiiService):
         return res_header, res_invoice
 
     def deregister_invoice(self):
-        msg_header, msg_invoice = self.get_deregister_msg()
+        msg_header, msg_invoice = self.get_msg()
         try:
             if self.invoice.type.startswith('out_'):
                 res = self.emitted_service.AnulacionLRFacturasEmitidas(

--- a/sii/server.py
+++ b/sii/server.py
@@ -202,7 +202,7 @@ class SiiService(Service):
 
 class SiiDeregisterService(SiiService):
 
-    def get_deregister_msg(self):
+    def get_msg(self):
         dict_from_marsh = (
             SIIDeregister(self.invoice).generate_deregister_object()
         )
@@ -241,7 +241,7 @@ class SiiDeregisterService(SiiService):
             self.result = fault
             raise fault
 
-    def deregister(self, invoice):
+    def send(self, invoice):
         self.invoice = invoice
         if self.invoice.type.startswith('out_'):
             if self.emitted_service is None:

--- a/sii/utils.py
+++ b/sii/utils.py
@@ -27,7 +27,7 @@ class FiscalPartner(object):
                 self.name = invoice.fiscal_name
             else:
                 self.name = invoice.partner_id.name
-            if hasattr(invoice, 'fiscal_vat') and invoice.fiscal_name:
+            if hasattr(invoice, 'fiscal_vat') and invoice.fiscal_vat:
                 self.vat = invoice.fiscal_vat
             else:
                 self.vat = invoice.partner_id.vat

--- a/sii/utils.py
+++ b/sii/utils.py
@@ -10,10 +10,8 @@ def unidecode_str(s):
     return unidecode(s)
 
 class FiscalPartner(object):
-    def __init__(
-            self, invoice,
-            name=None, vat=None, aeat_registered=None,
-            partner_country=None
+    def __init__(self, invoice=None, name=None, vat=None,
+                 aeat_registered=None, partner_country=None
     ):
         """
         :param invoice: Invoce from take info
@@ -22,9 +20,17 @@ class FiscalPartner(object):
         :param aeat_registered: Fiscal partner is registered on aeat
         :param partner_country: Fiscal partner country
         """
+        if invoice is None and name is None and vat is None:
+            raise ValueError('Missing invoice or manual values')
         if invoice:
-            self.name = invoice.partner_id.name
-            self.vat = invoice.partner_id.vat
+            if hasattr(invoice, 'fiscal_name') and invoice.fiscal_name:
+                self.name = invoice.fiscal_name
+            else:
+                self.name = invoice.partner_id.name
+            if hasattr(invoice, 'fiscal_vat') and invoice.fiscal_name:
+                self.vat = invoice.fiscal_vat
+            else:
+                self.vat = invoice.partner_id.vat
             self.aeat_registered = invoice.partner_id.aeat_registered
             self.partner_country = invoice.partner_id.country_id or invoice.partner_id.country
         else:

--- a/sii/utils.py
+++ b/sii/utils.py
@@ -9,6 +9,33 @@ def unidecode_str(s):
         s = s.decode('utf-8')
     return unidecode(s)
 
+class FiscalPartner(object):
+    def __init__(
+            self, invoice,
+            name=None, vat=None, aeat_registered=None,
+            partner_country=None
+    ):
+        """
+        :param invoice: Invoce from take info
+        :param name: Fiscal partner name
+        :param vat: Fiscal partner vat
+        :param aeat_registered: Fiscal partner is registered on aeat
+        :param partner_country: Fiscal partner country
+        """
+        if invoice:
+            self.name = invoice.partner_id.name
+            self.vat = invoice.partner_id.vat
+            self.aeat_registered = invoice.partner_id.aeat_registered
+            self.partner_country = invoice.partner_id.country_id or invoice.partner_id.country
+        else:
+            self.name = name
+            self.vat = vat
+            self.aeat_registered = aeat_registered
+            self.partner_country = partner_country
+
+    def sii_get_vat_type(self):
+        return VAT.sii_get_vat_type(self.vat)
+
 
 class VAT:
     def __init__(self, vat):

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -1062,7 +1062,7 @@ with description('El XML Generado en una baja de una factura emitida'):
         with before.all:
             self.invoice = self.data_gen.get_out_invoice()
             self.invoice_obj = (
-                SIIDeregister(self.invoice).generate_deregister_object()
+                SIIDeregister(self.invoice).generate_object()
             )
             self.cabecera = (
                 self.invoice_obj['BajaLRFacturasEmitidas']['Cabecera']
@@ -1093,7 +1093,7 @@ with description('El XML Generado en una baja de una factura emitida'):
         with before.all:
             self.invoice = self.data_gen.get_out_invoice()
             self.invoice_obj = (
-                SIIDeregister(self.invoice).generate_deregister_object()
+                SIIDeregister(self.invoice).generate_object()
             )
             self.factura_emitida = (
                 self.invoice_obj['BajaLRFacturasEmitidas']
@@ -1149,7 +1149,7 @@ with description('El XML Generado en una baja de una factura recibida'):
         with before.all:
             self.invoice = self.data_gen.get_in_invoice()
             self.invoice_obj = (
-                SIIDeregister(self.invoice).generate_deregister_object()
+                SIIDeregister(self.invoice).generate_object()
             )
             self.cabecera = (
                 self.invoice_obj['BajaLRFacturasRecibidas']['Cabecera']
@@ -1180,7 +1180,7 @@ with description('El XML Generado en una baja de una factura recibida'):
         with before.all:
             self.invoice = self.data_gen.get_in_invoice()
             self.invoice_obj = (
-                SIIDeregister(self.invoice).generate_deregister_object()
+                SIIDeregister(self.invoice).generate_object()
             )
             self.factura_recibida = (
                 self.invoice_obj['BajaLRFacturasRecibidas']

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -124,13 +124,13 @@ with description('El XML Generado'):
                     self.nifs_test_obj['SuministroLRFacturasEmitidas']
                     ['RegistroLRFacturasEmitidas']['FacturaExpedida']
                     ['Contraparte']['NombreRazon']
-                ).to(equal(self.nombre_contraparte))
-            with it('el Nombre de la Contraparte debe ser distinto al del partner'):
+                ).to(equal(self.nombre_partner))
+            with it('el Nombre de la Contraparte debe ser igual al del partner'):
                 expect(
                     self.nifs_test_obj['SuministroLRFacturasEmitidas']
                     ['RegistroLRFacturasEmitidas']['FacturaExpedida']
                     ['Contraparte']['NombreRazon']
-                ).not_to(equal(self.nombre_partner))
+                ).to(equal(self.nombre_partner))
 
         with context('en los NIFs involucrados con fiscal info'):
             with before.all:

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -90,14 +90,17 @@ with description('El XML Generado'):
                 ['RegistroLRFacturasEmitidas']
             )
 
-        with context('en los NIFs involucrados'):
+        with context('en los NIFs involucrados sin fiscal info'):
             with before.all:
                 os.environ['NIF_TITULAR'] = 'ES12345678T'
                 os.environ['NIF_CONTRAPARTE'] = 'esES654321P'
+                os.environ['FISCAL_VAT_CONTRAPARTE'] = 'esES654321P'
 
                 new_data_gen = DataGenerator()
-                nifs_test_invoice = new_data_gen.get_out_invoice()
+                nifs_test_invoice = new_data_gen.get_out_invoice(with_fiscal_info=False)
                 self.nif_contraparte = nifs_test_invoice.partner_id.vat[2:]
+                self.nombre_contraparte = unidecode_str(nifs_test_invoice.partner_id.name)
+                self.nombre_partner = unidecode_str(nifs_test_invoice.partner_id.name)
                 self.nif_titular = (
                     nifs_test_invoice.company_id.partner_id.vat[2:]
                 )
@@ -116,6 +119,60 @@ with description('El XML Generado'):
                     ['RegistroLRFacturasEmitidas']['FacturaExpedida']
                     ['Contraparte']['NIF']
                 ).to(equal(self.nif_contraparte))
+            with it('el Nombre de la Contraparte debe ser igual al valor partner'):
+                expect(
+                    self.nifs_test_obj['SuministroLRFacturasEmitidas']
+                    ['RegistroLRFacturasEmitidas']['FacturaExpedida']
+                    ['Contraparte']['NombreRazon']
+                ).to(equal(self.nombre_contraparte))
+            with it('el Nombre de la Contraparte debe ser distinto al del partner'):
+                expect(
+                    self.nifs_test_obj['SuministroLRFacturasEmitidas']
+                    ['RegistroLRFacturasEmitidas']['FacturaExpedida']
+                    ['Contraparte']['NombreRazon']
+                ).not_to(equal(self.nombre_partner))
+
+        with context('en los NIFs involucrados con fiscal info'):
+            with before.all:
+                os.environ['NIF_TITULAR'] = 'ES12345678T'
+                os.environ['NIF_CONTRAPARTE'] = 'esES654321P'
+                os.environ['FISCAL_VAT_CONTRAPARTE'] = 'esES654321P'
+
+                new_data_gen = DataGenerator()
+                nifs_test_invoice = new_data_gen.get_out_invoice()
+                self.nif_contraparte = nifs_test_invoice.fiscal_vat[2:]
+                self.nif_titular = (
+                    nifs_test_invoice.company_id.partner_id.vat[2:]
+                )
+                self.nombre_contraparte = nifs_test_invoice.fiscal_name
+                self.nombre_partner = nifs_test_invoice.partner_id.name
+
+                self.nifs_test_obj = SII(nifs_test_invoice).generate_object()
+
+            with it('el NIF del Titular no debe empezar por "ES"'):
+                expect(
+                    self.nifs_test_obj['SuministroLRFacturasEmitidas']
+                    ['Cabecera']['Titular']['NIF']
+                ).to(equal(self.nif_titular))
+
+            with it('el NIF de la Contraparte no debe empezar por "ES"'):
+                expect(
+                    self.nifs_test_obj['SuministroLRFacturasEmitidas']
+                    ['RegistroLRFacturasEmitidas']['FacturaExpedida']
+                    ['Contraparte']['NIF']
+                ).to(equal(self.nif_contraparte))
+            with it('el Nombre de la Contraparte debe ser igual al valor fiscal'):
+                expect(
+                    self.nifs_test_obj['SuministroLRFacturasEmitidas']
+                    ['RegistroLRFacturasEmitidas']['FacturaExpedida']
+                    ['Contraparte']['NombreRazon']
+                ).to(equal(self.nombre_contraparte))
+            with it('el Nombre de la Contraparte debe ser distinto al del partner'):
+                expect(
+                    self.nifs_test_obj['SuministroLRFacturasEmitidas']
+                    ['RegistroLRFacturasEmitidas']['FacturaExpedida']
+                    ['Contraparte']['NombreRazon']
+                ).not_to(equal(self.nombre_partner))
 
         with it('la ClaveRegimenEspecialOTrascendencia debe ser válido'):
             expect(

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -72,6 +72,10 @@ class DataGenerator:
             invoice_tax_iva_exento
         ]
         spain = Country(code='ES', is_eu_member=False)
+        self.fiscal_name = os.environ.get(
+            'FISCAL_NOMBRE_CONTRAPARTE', u'Qwerting Tarantino')
+        self.fiscal_vat = os.environ.get(
+            'FISCAL_VAT_CONTRAPARTE', u'ES09346536A')
         self.partner_invoice = Partner(
             name=os.environ.get('NOMBRE_CONTRAPARTE', u'Francisco García'),
             nif=os.environ.get('NIF_CONTRAPARTE', u'ES12345678Z'),
@@ -132,7 +136,7 @@ class DataGenerator:
         )
         return invoice
 
-    def get_out_invoice(self):
+    def get_out_invoice(self, with_fiscal_info=True):
         journal = Journal(
             name=u'Factura de Energía Emitida'
         )
@@ -144,6 +148,9 @@ class DataGenerator:
             rectifying_id=False,
             number='FEmit{}'.format(self.invoice_number),
             partner_id=self.partner_invoice,
+            fiscal_info=with_fiscal_info,
+            fiscal_name=self.fiscal_name,
+            fiscal_vat=self.fiscal_vat,
             address_contact_id=self.address_contact_id,
             company_id=self.company,
             amount_total=self.amount_total,

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -171,31 +171,52 @@ class DataGenerator:
         journal = Journal(
             name=u'Factura de Energía Emitida'
         )
-
-        invoice = Invoice(
-            invoice_type='out_invoice',
-            journal_id=journal,
-            rectificative_type='N',
-            rectifying_id=False,
-            number='FEmit{}'.format(self.invoice_number),
-            partner_id=self.partner_invoice,
-            fiscal_info=with_fiscal_info,
-            fiscal_name=self.fiscal_name,
-            fiscal_vat=self.fiscal_vat,
-            address_contact_id=self.address_contact_id,
-            company_id=self.company,
-            amount_total=self.amount_total,
-            amount_untaxed=self.amount_untaxed,
-            amount_tax=self.amount_tax,
-            period_id=self.period,
-            date_invoice=self.date_invoice,
-            tax_line=self.tax_line,
-            invoice_line=self.invoice_line,
-            sii_registered=self.sii_registered,
-            fiscal_position=self.fiscal_position,
-            sii_description=self.sii_description,
-            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
-        )
+        if with_fiscal_info:
+            invoice = Invoice(
+                invoice_type='out_invoice',
+                journal_id=journal,
+                rectificative_type='N',
+                rectifying_id=False,
+                number='FEmit{}'.format(self.invoice_number),
+                partner_id=self.partner_invoice,
+                fiscal_name=self.fiscal_name,
+                fiscal_vat=self.fiscal_vat,
+                address_contact_id=self.address_contact_id,
+                company_id=self.company,
+                amount_total=self.amount_total,
+                amount_untaxed=self.amount_untaxed,
+                amount_tax=self.amount_tax,
+                period_id=self.period,
+                date_invoice=self.date_invoice,
+                tax_line=self.tax_line,
+                invoice_line=self.invoice_line,
+                sii_registered=self.sii_registered,
+                fiscal_position=self.fiscal_position,
+                sii_description=self.sii_description,
+                sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+            )
+        else:
+            invoice = Invoice(
+                invoice_type='out_invoice',
+                journal_id=journal,
+                rectificative_type='N',
+                rectifying_id=False,
+                number='FEmit{}'.format(self.invoice_number),
+                partner_id=self.partner_invoice,
+                address_contact_id=self.address_contact_id,
+                company_id=self.company,
+                amount_total=self.amount_total,
+                amount_untaxed=self.amount_untaxed,
+                amount_tax=self.amount_tax,
+                period_id=self.period,
+                date_invoice=self.date_invoice,
+                tax_line=self.tax_line,
+                invoice_line=self.invoice_line,
+                sii_registered=self.sii_registered,
+                fiscal_position=self.fiscal_position,
+                sii_description=self.sii_description,
+                sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+            )
         return invoice
 
     def get_in_refund_invoice(self):


### PR DESCRIPTION
Cuando una factura tiene esta informació fiscal esta se debe utilizar por encima de los datos del partner. 

- Esto es necesario para poder garantizar el envio de una anulación.

- Refactor SiiDeregisterService y del SIIDeregister rompiendo compatibilidad con versiones anteriores