### PR TITLE
Corrección envio base rectificada y Cuota Rectificada con el mismo signo original 

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -359,10 +359,9 @@ def get_fact_rect_sustitucion_fields(invoice, opcion=False):
         for iva in detalle_iva:
             base_rectificada += iva['BaseImponible']
             cuota_rectificada += iva.get(cuota_key, 0)
-
         rectificativa_fields['ImporteRectificacion'] = {
-            'BaseRectificada': abs(base_rectificada),
-            'CuotaRectificada': abs(cuota_rectificada)
+            'BaseRectificada': base_rectificada,
+            'CuotaRectificada': cuota_rectificada
         }
     elif opcion == 2:
         rectificativa_fields['ImporteRectificacion'] = {

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -1106,6 +1106,10 @@ with description('El XML Generado'):
                 self.in_invoice_RA_obj['SuministroLRFacturasRecibidas']
                 ['RegistroLRFacturasRecibidas']
             )
+            self.fact_origin = (
+                self.in_invoice_origin_obj['SuministroLRFacturasRecibidas']
+                ['RegistroLRFacturasRecibidas']
+            )
 
         with context('en los datos de rectificación'):
             with it('el TipoRectificativa debe ser por sustitución (S)'):
@@ -1148,6 +1152,27 @@ with description('El XML Generado'):
                     ['ImporteRectificacion']['CuotaRectificada']
                 ).to(equal(
                     -79.0
+                ))
+            with it('los Importes de rectificacion debe ser igual que los datos de la factura original'):
+                base_presentada = sum(x['BaseImponible'] for x in
+                    self.fact_origin['FacturaRecibida']['DesgloseFactura'][
+                        'DesgloseIVA']['DetalleIVA'])
+                cuota_presentada = sum(
+                    x.get('CuotaSoportada', 0.0) for x in
+                    self.fact_origin['FacturaRecibida'][
+                        'DesgloseFactura']['DesgloseIVA']['DetalleIVA'])
+                expect(
+                    self.fact_RA_recibida['FacturaRecibida']
+                    ['ImporteRectificacion']['BaseRectificada']
+                ).to(equal(
+                    base_presentada
+                ))
+
+                expect(
+                    self.fact_RA_recibida['FacturaRecibida']
+                    ['ImporteRectificacion']['CuotaRectificada']
+                ).to(equal(
+                    cuota_presentada
                 ))
 
 with description('El XML Generado en una baja de una factura emitida'):

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -1147,7 +1147,7 @@ with description('El XML Generado'):
                     self.fact_RA_recibida['FacturaRecibida']
                     ['ImporteRectificacion']['CuotaRectificada']
                 ).to(equal(
-                    79
+                    -79.0
                 ))
 
 with description('El XML Generado en una baja de una factura emitida'):


### PR DESCRIPTION
Fuente: https://www.agenciatributaria.es/static_files/AEAT/Contenidos_Comunes/La_Agencia_Tributaria/Modelos_y_formularios/Suministro_inmediato_informacion/FicherosSuministros/V_1_1/SII_Descripcion_ServicioWeb_v1.1.pdf


![imatge](https://user-images.githubusercontent.com/4963636/228730830-a9ebc812-8b47-40b5-aece-a6ee20a55284.png)

## Error
En facturas negativas cuando son rectificadas por sustiución se mandaba siempre la Base y la Cuota rectificada en valor absoluto.

## Corrección

Se elimina el valor absoluto para el envío del valor tal cual se mando con la factura original
