### PR TITLE
Enviar fecha operacion para A, B y R

### DIFF
--- a/sii/models/invoices_record.py
+++ b/sii/models/invoices_record.py
@@ -537,6 +537,7 @@ class DetalleFactura(MySchema):
     TipoRectificativa = CustomStringField()  # TODO obligatorio si es una rectificativa
     ImporteRectificacion = fields.Nested(ImporteRectificacion)  # TODO obligatorio si TipoRectificativa = 'S'
     FacturasRectificadas = fields.Nested(FacturasRectificadas)  # TODO opcional si TipoFactura = Rectificativa
+    FechaOperacion = DateString()
     # TODO ImporteTotal OBLIGATORIO si:
     # 1.Obligatorio si Baseimponible=0 y TipoFactura=”F2” o “R5”
     # 2.Obligatorio si Baseimponible=0 y ClaveRegimenEspecialOTranscedencia = “05”o “03”

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -334,7 +334,8 @@ def get_fact_rect_sustitucion_fields(invoice, opcion=False):
     :return:
     """
     rectificativa_fields = {
-        'TipoRectificativa': 'S'  # Por sustitución
+        'TipoRectificativa': 'S',  # Por sustitución
+        'FechaOperacion': invoice.rectifying_id.date_invoice
     }
 
     if opcion == 1:
@@ -424,7 +425,10 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
         factura_expedida['DatosInmueble'] = {
             'DetalleInmueble': detalle_inmueble
         }
-
+    if invoice.type in ('A', 'B'):
+        factura_expedida.update(
+            {'FechaOperacion': invoice.rectifying_id.date_invoice}
+        )
     if rectificativa:
         opcion = 0
         if rect_sust_opc1:

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -286,6 +286,12 @@ def get_factura_emitida_tipo_desglose(invoice):
 
     return tipo_desglose
 
+def get_fecha_operacion_rec(invoice):
+    if invoice.rectificative_type == 'N':
+        return invoice.date_invoice
+    else:
+        return get_fecha_operacion_rec(invoice.rectifying_id)
+
 
 def get_fact_rect_sustitucion_fields(invoice, opcion=False):
     """
@@ -335,7 +341,7 @@ def get_fact_rect_sustitucion_fields(invoice, opcion=False):
     """
     rectificativa_fields = {
         'TipoRectificativa': 'S',  # Por sustitución
-        'FechaOperacion': invoice.rectifying_id.date_invoice
+        'FechaOperacion': get_fecha_operacion_rec(invoice)
     }
 
     if opcion == 1:
@@ -427,7 +433,7 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
         }
     if invoice.rectificative_type in ('A', 'B'):
         factura_expedida.update(
-            {'FechaOperacion': invoice.rectifying_id.date_invoice}
+            {'FechaOperacion': get_fecha_operacion_rec(invoice)}
         )
     if rectificativa:
         opcion = 0

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -425,7 +425,7 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
         factura_expedida['DatosInmueble'] = {
             'DetalleInmueble': detalle_inmueble
         }
-    if invoice.type in ('A', 'B'):
+    if invoice.rectificative_type in ('A', 'B'):
         factura_expedida.update(
             {'FechaOperacion': invoice.rectifying_id.date_invoice}
         )

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -917,18 +917,32 @@ with description('El XML Generado'):
 
     with description('en los datos de una factura rectificativa emitida'):
         with before.all:
-            self.out_refund = self.data_gen.get_out_refund_invoice()
+            self.out_refund, self.out_b_inovice = self.data_gen.get_out_refund_invoice()
             self.out_refund_obj = SII(self.out_refund).generate_object()
+            self.out_b_inovice_obj = SII(self.out_b_inovice).generate_object()
             self.fact_rect_emit = (
                 self.out_refund_obj['SuministroLRFacturasEmitidas']
                 ['RegistroLRFacturasEmitidas']
             )
-
+            self.fact_refund_emit = (
+                self.out_b_inovice_obj['SuministroLRFacturasEmitidas']
+                ['RegistroLRFacturasEmitidas']
+            )
+        with context('en los datos de abonadora'):
+            with it('la FechaOperacion debe ser por factura original'):
+                expect(
+                    self.fact_refund_emit['FacturaExpedida']['FechaOperacion']
+                ).to(equal('31-12-2016'))
         with context('en los datos de rectificación'):
             with it('el TipoRectificativa debe ser por sustitución (S)'):
                 expect(
                     self.fact_rect_emit['FacturaExpedida']['TipoRectificativa']
                 ).to(equal('S'))
+
+            with it('la FechaOperacion debe ser por factura original'):
+                expect(
+                    self.fact_rect_emit['FacturaExpedida']['FechaOperacion']
+                ).to(equal('31-12-2016'))
 
             with before.all:
                 self.importe_rectificacion = (
@@ -961,7 +975,7 @@ with description('El XML Generado'):
                 expect(
                     self.grouped_detalle_iva[21.0]['BaseImponible']
                 ).to(equal(
-                    -1 * abs(self.out_refund.tax_line[0].base)
+                    self.out_refund.tax_line[0].base
                 ))
             with it('la CuotaRepercutida debe ser la original'):
                 expect(
@@ -975,6 +989,30 @@ with description('El XML Generado'):
                 ).to(equal(
                     self.out_refund.tax_line[0].tax_id.amount * 100
                 ))
+
+    with description('en los datos de una factura rectificativa de una rectificativa emitida'):
+        with before.all:
+            self.out_refund, self.out_b_inovice = self.data_gen.get_out_refund_mulitple_invoice()
+            self.out_refund_obj = SII(self.out_refund).generate_object()
+            self.out_b_inovice_obj = SII(self.out_b_inovice).generate_object()
+            self.fact_rect_emit = (
+                self.out_refund_obj['SuministroLRFacturasEmitidas']
+                ['RegistroLRFacturasEmitidas']
+            )
+            self.fact_refund_emit = (
+                self.out_b_inovice_obj['SuministroLRFacturasEmitidas']
+                ['RegistroLRFacturasEmitidas']
+            )
+        with context('en los datos de abonadora'):
+            with it('la FechaOperacion debe ser por factura original'):
+                expect(
+                    self.fact_refund_emit['FacturaExpedida']['FechaOperacion']
+                ).to(equal('07-12-2023'))
+        with context('en los datos de rectificación'):
+            with it('la FechaOperacion debe ser por factura original'):
+                expect(
+                    self.fact_rect_emit['FacturaExpedida']['FechaOperacion']
+                ).to(equal('07-12-2023'))
 
     with description('en los datos de una factura rectificativa recibida'):
         with before.all:

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -354,9 +354,12 @@ class DataGenerator:
         journal = Journal(
             name=u'Factura de Energía Rectificativa Emitida'
         )
+        rect_tax_line = self.tax_line[:]
+        for invoice_tax in rect_tax_line:
+            invoice_tax.tax_amount = -1 * abs(invoice_tax.tax_amount)
 
-        tax_line = self.tax_line
-        for invoice_tax in tax_line:
+        refund_tax_line = self.tax_line[:]
+        for invoice_tax in refund_tax_line:
             invoice_tax.tax_amount = -1 * abs(invoice_tax.tax_amount)
 
         rect_invoice = Invoice(
@@ -381,8 +384,8 @@ class DataGenerator:
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
         )
 
-        invoice = Invoice(
-            invoice_type='out_refund',
+        r_invoice = Invoice(
+            invoice_type='out_invoice',
             journal_id=journal,
             rectificative_type='R',
             rectifying_id=rect_invoice,
@@ -395,14 +398,155 @@ class DataGenerator:
             amount_tax=self.amount_tax,
             period_id=self.period,
             date_invoice=self.date_invoice,
-            tax_line=tax_line,
+            tax_line=rect_tax_line,
             invoice_line=self.invoice_line,
             sii_registered=self.sii_registered,
             fiscal_position=self.fiscal_position,
             sii_description=self.sii_description,
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
         )
-        return invoice
+        b_invoice = Invoice(
+            invoice_type='out_refund',
+            journal_id=journal,
+            rectificative_type='B',
+            rectifying_id=rect_invoice,
+            number='FAboEmit{}'.format(self.invoice_number),
+            partner_id=self.partner_invoice,
+            address_contact_id=self.address_contact_id,
+            company_id=self.company,
+            amount_total=-1.0 * self.amount_total,
+            amount_untaxed=-1.0 * self.amount_untaxed,
+            amount_tax=-1.0 * self.amount_tax,
+            period_id=self.period,
+            date_invoice=self.date_invoice,
+            tax_line=refund_tax_line,
+            invoice_line=self.invoice_line,
+            sii_registered=self.sii_registered,
+            fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+        )
+        return r_invoice, b_invoice
+
+    def get_out_refund_mulitple_invoice(self):
+        journal = Journal(
+            name=u'Factura de Energía Rectificativa Emitida'
+        )
+        rect_tax_line = self.tax_line[:]
+        for invoice_tax in rect_tax_line:
+            invoice_tax.tax_amount = -1 * abs(invoice_tax.tax_amount)
+
+        refund_tax_line = self.tax_line[:]
+        for invoice_tax in refund_tax_line:
+            invoice_tax.tax_amount = -1 * abs(invoice_tax.tax_amount)
+
+        orig_invoice = Invoice(
+            invoice_type='out_invoice',
+            journal_id=journal,
+            rectificative_type='N',
+            rectifying_id=False,
+            number='FEmitRectificada{}'.format(self.invoice_number),
+            partner_id=self.partner_invoice,
+            address_contact_id=self.address_contact_id,
+            company_id=self.company,
+            amount_total=self.amount_total,
+            amount_untaxed=self.amount_untaxed,
+            amount_tax=self.amount_tax,
+            period_id=self.period,
+            date_invoice='2023-12-07',
+            tax_line=self.tax_line,
+            invoice_line=self.invoice_line,
+            sii_registered=self.sii_registered,
+            fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+        )
+
+        r1_invoice = Invoice(
+            invoice_type='out_invoice',
+            journal_id=journal,
+            rectificative_type='R',
+            rectifying_id=orig_invoice,
+            number='FRectEmit{}'.format(self.invoice_number),
+            partner_id=self.partner_invoice,
+            address_contact_id=self.address_contact_id,
+            company_id=self.company,
+            amount_total=self.amount_total,
+            amount_untaxed=self.amount_untaxed,
+            amount_tax=self.amount_tax,
+            period_id=self.period,
+            date_invoice='2024-01-07',
+            tax_line=rect_tax_line,
+            invoice_line=self.invoice_line,
+            sii_registered=self.sii_registered,
+            fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+        )
+        b1_invoice = Invoice(
+            invoice_type='out_refund',
+            journal_id=journal,
+            rectificative_type='B',
+            rectifying_id=orig_invoice,
+            number='FAboEmit{}'.format(self.invoice_number),
+            partner_id=self.partner_invoice,
+            address_contact_id=self.address_contact_id,
+            company_id=self.company,
+            amount_total=-1.0 * self.amount_total,
+            amount_untaxed=-1.0 * self.amount_untaxed,
+            amount_tax=-1.0 * self.amount_tax,
+            period_id=self.period,
+            date_invoice='2024-01-07',
+            tax_line=refund_tax_line,
+            invoice_line=self.invoice_line,
+            sii_registered=self.sii_registered,
+            fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+        )
+        r2_invoice = Invoice(
+            invoice_type='out_invoice',
+            journal_id=journal,
+            rectificative_type='R',
+            rectifying_id=r1_invoice,
+            number='FRect2Emit{}'.format(self.invoice_number),
+            partner_id=self.partner_invoice,
+            address_contact_id=self.address_contact_id,
+            company_id=self.company,
+            amount_total=self.amount_total,
+            amount_untaxed=self.amount_untaxed,
+            amount_tax=self.amount_tax,
+            period_id=self.period,
+            date_invoice='2024-02-07',
+            tax_line=rect_tax_line,
+            invoice_line=self.invoice_line,
+            sii_registered=self.sii_registered,
+            fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+        )
+        b2_invoice = Invoice(
+            invoice_type='out_refund',
+            journal_id=journal,
+            rectificative_type='B',
+            rectifying_id=r1_invoice,
+            number='FAbo2Emit{}'.format(self.invoice_number),
+            partner_id=self.partner_invoice,
+            address_contact_id=self.address_contact_id,
+            company_id=self.company,
+            amount_total=-1.0 * self.amount_total,
+            amount_untaxed=-1.0 * self.amount_untaxed,
+            amount_tax=-1.0 * self.amount_tax,
+            period_id=self.period,
+            date_invoice='2024-02-07',
+            tax_line=refund_tax_line,
+            invoice_line=self.invoice_line,
+            sii_registered=self.sii_registered,
+            fiscal_position=self.fiscal_position,
+            sii_description=self.sii_description,
+            sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+        )
+        return r2_invoice, b2_invoice
 
     def get_out_invoice_RA(self):
         journal = Journal(
@@ -550,7 +694,7 @@ class DataGenerator:
             invoice_type='out_refund',
             journal_id=journal,
             rectificative_type='A',
-            rectifying_id=False,
+            rectifying_id=rect_invoice,
             number='FRectEmit{}'.format(self.invoice_number),
             partner_id=self.partner_invoice,
             address_contact_id=self.address_contact_id,


### PR DESCRIPTION
Añadir compatibilidad con las restricciones introducidas en las validaciones de la fecha de Operación:

- [Enlace validaciones PDF](https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G417/FicherosSuministros/V_1_1/Validaciones_ErroresSII_v1.1.pdf)
   -  Punto 3.1.4.1 

- Revisando la documentación en el punto 2.8  se usa la opción 2, donde se emite una factura abonadora y una rectificadora. [Enlace documentación web](https://sede.agenciatributaria.gob.es/Sede/impuestos-tasas/iva/iva-libros-registro-iva-traves-aeat/preguntas-frecuentes/2-registro-cuestiones-comunes.html?faqId=8aad6c3d02bc9510VgnVCM100000dc381e0aRCRD)

En ningún momento de la documentación se añade o incluso se indica que se deje en blanco:

![image](https://github.com/user-attachments/assets/f30865a0-6cb8-40fc-a7ae-b8bbb3d982de)

## Cambio
Se añade la fecha de operación en las facturas que sean del tipo rectificativo A, B, R y RA para que se incorpore la fecha de operación de la primera factura para poder enviar las facturas de este tipo.

Se tiene en cuenta que una factura rectificadora/anuladora de una factura ya rectificada vaya a buscar la fecha de la primera factura.

