### PR TITLE
Envío tipo impositivo como S y R4 para facturas abonadoras con tipos impositivos fuera de vigencia

### DIFF
--- a/sii/models/basic_models.py
+++ b/sii/models/basic_models.py
@@ -109,7 +109,8 @@ class Invoice:
                  origin_date_invoice=None,
                  origin=None,
                  fiscal_name=None,
-                 fiscal_vat=None):
+                 fiscal_vat=None,
+                 sii_non_current_tax_rate='R4'):
         self.journal_id = journal_id
         self.number = number
         self.type = invoice_type
@@ -136,3 +137,18 @@ class Invoice:
         self.sii_out_clave_regimen_especial = sii_out_clave_regimen_especial
         self.rectificative_type = rectificative_type
         self.rectifying_id = rectifying_id
+        self.sii_non_current_tax_rate = sii_non_current_tax_rate
+
+    def get_values_taxes_non_current_tax_rate(self):
+        if self.sii_non_current_tax_rate == 'R4':
+            return {
+                'TipoRectificativa': 'S',
+                'TipoFactura': 'R4',
+                'ImporteRectificacion': {
+                    'BaseRectificada': 0,
+                    'CuotaRectificada': 0
+                }
+            }
+        else:
+            return {}
+        

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -445,18 +445,15 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
 
     if invoice.rectificative_type in ('A', 'B'):
         if tipo_impositivo_no_vigente:
-            if invoice.date_invoice >  tipo_impositivo_no_vigente:
+            if invoice.date_invoice > tipo_impositivo_no_vigente:
                 factura_expedida.update(
                     {
-                        'FechaOperacion': get_fecha_operacion_rec(invoice),
-                        'TipoRectificativa': 'S',
-                        'TipoFactura': 'R4',
-                        'ImporteRectificacion': {
-                            'BaseRectificada': 0,
-                            'CuotaRectificada': 0
-                        }
+                        'FechaOperacion': get_fecha_operacion_rec(invoice)
                     }
                 )
+                extra_info = invoice.get_values_taxes_non_current_tax_rate()
+                if extra_info:
+                    factura_expedida.update(extra_info)
     if rectificativa:
         opcion = 0
         if rect_sust_opc1:

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -447,10 +447,16 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
         if tipo_impositivo_no_vigente:
             if invoice.date_invoice >  tipo_impositivo_no_vigente:
                 factura_expedida.update(
-                    {'FechaOperacion': get_fecha_operacion_rec(invoice),
-                    'TipoRectificativa': 'S',
-                    'TipoFactura': 'R4'
-                })
+                    {
+                        'FechaOperacion': get_fecha_operacion_rec(invoice),
+                        'TipoRectificativa': 'S',
+                        'TipoFactura': 'R4',
+                        'ImporteRectificacion': {
+                            'BaseRectificada': 0,
+                            'CuotaRectificada': 0
+                        }
+                    }
+                )
     if rectificativa:
         opcion = 0
         if rect_sust_opc1:

--- a/sii/resource.py
+++ b/sii/resource.py
@@ -447,8 +447,10 @@ def get_factura_emitida(invoice, rect_sust_opc1=False, rect_sust_opc2=False):
         if tipo_impositivo_no_vigente:
             if invoice.date_invoice >  tipo_impositivo_no_vigente:
                 factura_expedida.update(
-                    {'FechaOperacion': get_fecha_operacion_rec(invoice)}
-                )
+                    {'FechaOperacion': get_fecha_operacion_rec(invoice),
+                    'TipoRectificativa': 'S',
+                    'TipoFactura': 'R4'
+                })
     if rectificativa:
         opcion = 0
         if rect_sust_opc1:

--- a/spec/serialization_spec.py
+++ b/spec/serialization_spec.py
@@ -1008,6 +1008,15 @@ with description('El XML Generado'):
                 expect(
                      self.fact_refund_emit['FacturaExpedida']['FechaOperacion']
                 ).to(equal('01-01-2023'))
+            with it('la TipoRectificativa debe ser S'):
+                expect(
+                    self.fact_refund_emit['FacturaExpedida']['TipoRectificativa']
+                ).to(equal('S'))
+            with it('la TipoFactura tiene que ser R4'):
+                expect(
+                    self.fact_refund_emit['FacturaExpedida'][
+                        'TipoFactura']
+                ).to(equal('R4'))
         with context('en los datos de rectificación'):
             with it('el TipoRectificativa debe ser por sustitución (S)'):
                 expect(
@@ -1084,6 +1093,14 @@ with description('El XML Generado'):
                      self.fact_refund_emit['FacturaExpedida'].get(
                          'FechaOperacion', False)
                 ).to(equal(False))
+            with it('la TipoRectificativa NO debe ser informado'):
+                expect(
+                    self.fact_refund_emit['FacturaExpedida'].get('TipoRectificativa',False)
+                ).to(equal(False))
+            with it('la TipoFactura tiene que ser F1'):
+                expect(
+                    self.fact_refund_emit['FacturaExpedida'].get('TipoFactura', False)
+                ).to(equal('F1'))
         with context('en los datos de rectificación'):
             with it('el TipoRectificativa debe ser por sustitución (S)'):
                 expect(
@@ -1094,6 +1111,15 @@ with description('El XML Generado'):
                 expect(
                     self.fact_rect_emit['FacturaExpedida'].get('FechaOperacion', False)
                 ).to(equal(False))
+            with it('la TipoRectificativa debe ser S'):
+                expect(
+                    self.fact_rect_emit['FacturaExpedida'].get('TipoRectificativa',False)
+                ).to(equal('S'))
+            with it('la TipoFactura tiene que ser R4'):
+                expect(
+                    self.fact_rect_emit['FacturaExpedida'][
+                        'TipoFactura']
+                ).to(equal('R4'))
 
             with before.all:
                 self.importe_rectificacion = (
@@ -1159,6 +1185,15 @@ with description('El XML Generado'):
                 expect(
                     self.fact_refund_emit['FacturaExpedida']['FechaOperacion']
                 ).to(equal('01-01-2023'))
+            with it('la TipoRectificativa debe ser S'):
+                expect(
+                    self.fact_refund_emit['FacturaExpedida']['TipoRectificativa']
+                ).to(equal('S'))
+            with it('la TipoFactura tiene que ser R4'):
+                expect(
+                    self.fact_refund_emit['FacturaExpedida'][
+                        'TipoFactura']
+                ).to(equal('R4'))
         with context('en los datos de rectificación'):
             with it('la FechaOperacion debe ser por factura original'):
                 expect(

--- a/spec/testing_data.py
+++ b/spec/testing_data.py
@@ -430,7 +430,7 @@ class DataGenerator:
         )
         return r_invoice, b_invoice
 
-    def get_out_refund_invoice_iva5(self, fecha_facturas_recti=None):
+    def get_out_refund_invoice_iva5(self, fecha_facturas_recti=None, sii_non_current_tax_rate='R4'):
         journal = Journal(
             name=u'Factura de Energía Rectificativa Emitida'
         )
@@ -482,6 +482,7 @@ class DataGenerator:
             fiscal_position=self.fiscal_position,
             sii_description=self.sii_description,
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+            sii_non_current_tax_rate=sii_non_current_tax_rate
         )
 
         r_invoice = Invoice(
@@ -504,6 +505,7 @@ class DataGenerator:
             fiscal_position=self.fiscal_position,
             sii_description=self.sii_description,
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+            sii_non_current_tax_rate = sii_non_current_tax_rate
         )
         b_invoice = Invoice(
             invoice_type='out_refund',
@@ -525,6 +527,7 @@ class DataGenerator:
             fiscal_position=self.fiscal_position,
             sii_description=self.sii_description,
             sii_out_clave_regimen_especial=self.sii_out_clave_regimen_especial,
+            sii_non_current_tax_rate=sii_non_current_tax_rate
         )
         return r_invoice, b_invoice
 


### PR DESCRIPTION

Añadir cambios en el envio de las facturas con tipo impositivo no vigente, para los abonos

* 'TipoRectificativa': 'S',
* 'TipoFactura': 'R4'