### PR TITLE
Fix asignación fecha de operacion cuando fact original es C

### DIFF
--- a/sii/resource.py
+++ b/sii/resource.py
@@ -326,7 +326,7 @@ def get_factura_emitida_tipo_desglose(invoice):
     return {'tipo_desglose': tipo_desglose, 'iva_values': iva_values}
 
 def get_fecha_operacion_rec(invoice):
-    if invoice.rectificative_type == 'N':
+    if invoice.rectificative_type in ('N', 'C') or not invoice.rectifying_id:
         return invoice.date_invoice
     else:
         return get_fecha_operacion_rec(invoice.rectifying_id)


### PR DESCRIPTION

#### Causa
- El método no contemplaba facturas de tipo **"C" (Complementaria)** como facturas originales.  
- En estos casos cuándo se intentaba acceder a la información inexistente ocasionando el error.

#### Solución
- Se ha ampliado la condición inicial para tratar tanto facturas de tipo **"N" (Normal)** como **"C" (Complementaria)**, o aquellas sin `rectifying_id`, como facturas originales.  
- De esta forma, se devuelve la `date_invoice` directamente y se evita el error de acceso al campo.
